### PR TITLE
Feat/create endpoint find neighbor by

### DIFF
--- a/src/auth/infrastructure/middlewares/validate-access-token.middleware.ts
+++ b/src/auth/infrastructure/middlewares/validate-access-token.middleware.ts
@@ -26,7 +26,6 @@ const validateAccessToken = async (
       return
     }
 
-
     switch (token.role) {
       case 'neighbor':
         req.neighbor = token

--- a/src/neighbor/aplication/usecases/find-by-id.usecase.ts
+++ b/src/neighbor/aplication/usecases/find-by-id.usecase.ts
@@ -1,0 +1,17 @@
+import type NeighborEntity from '../../domain/entities/neighbor.entity'
+import ErrorNeighborNotFound from '../../domain/errors/neighbor-not-found.error'
+import type NeighborRepository from '../../domain/repositories/neighbor.repository'
+
+class FindNeighborByIDUseCase {
+  constructor(private readonly repository: NeighborRepository) {
+    this.repository = repository
+  }
+
+  async exec(id: string): Promise<NeighborEntity> {
+    const neighbor = await this.repository.find({ id })
+    if (neighbor == null) throw new ErrorNeighborNotFound(id)
+    return neighbor
+  }
+}
+
+export default FindNeighborByIDUseCase

--- a/src/neighbor/aplication/usecases/list.usecase.ts
+++ b/src/neighbor/aplication/usecases/list.usecase.ts
@@ -1,0 +1,17 @@
+import type NeighborEntity from '../../domain/entities/neighbor.entity'
+import ErrorNeighborNotFound from '../../domain/errors/neighbor-not-found.error'
+import type NeighborRepository from '../../domain/repositories/neighbor.repository'
+
+class ListNeighborsUseCase {
+  constructor(private readonly repository: NeighborRepository) {
+    this.repository = repository
+  }
+
+  async exec(offset: number, limit: number): Promise<NeighborEntity[]> {
+    const neighbors = await this.repository.list(offset, limit)
+    if (neighbors == null || neighbors.length === 0) throw new ErrorNeighborNotFound(undefined, undefined, undefined)
+    return neighbors
+  }
+}
+
+export default ListNeighborsUseCase

--- a/src/neighbor/infrastructure/handler/neighbor.handler.ts
+++ b/src/neighbor/infrastructure/handler/neighbor.handler.ts
@@ -3,7 +3,7 @@ import AuthService from '../../../auth/aplicaction/service/auth.service'
 import type IJWTProvider from '../../../auth/domain/providers/jwt.interface.provider'
 import DateUtils from '../../../shared/utils/date.util'
 import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
-import { GetURLParams } from '../../../shared/utils/http.request.util'
+import { GetPaginationParams, GetURLParams } from '../../../shared/utils/http.request.util'
 import FindByEmailUseCase from '../../aplication/usecases/find-by-email.usecase'
 import LoginNeighborUseCase from '../../aplication/usecases/login.usecase'
 import RegisterNeighborUseCase from '../../aplication/usecases/register.usecase'
@@ -14,6 +14,7 @@ import CheckIdDTO from '../dtos/check-id.dto'
 import RegisterNeighborDTO from '../dtos/register-neighbor.dto'
 import UpdateNeighborDTO from '../dtos/update-neighbor.dto'
 import SchemaValidator from '../middlewares/zod-schema-validator.middleware'
+import ListNeighborsUseCase from '../../aplication/usecases/list.usecase'
 
 class NeighborHandler {
   constructor(
@@ -21,6 +22,17 @@ class NeighborHandler {
     private readonly jwtProvider: IJWTProvider
   ) {
     this.repository = repository
+  }
+
+  async list(req: FastifyRequest<{ Querystring: Record<string, string> }>, rep: FastifyReply): Promise<void> {
+    try {
+      const { offset, limit } = GetPaginationParams(req)
+
+      const usecase = new ListNeighborsUseCase(this.repository)
+      const neighbors = await usecase.exec(offset, limit)
+
+      HandleHTTPResponse.OK(rep, 'Neighbors retrieved successfully', neighbors)
+    } catch (error) {}
   }
 
   async findById(req: FastifyRequest<{ Params: Record<string, string> }>, rep: FastifyReply): Promise<void> {

--- a/src/neighbor/infrastructure/handler/neighbor.handler.ts
+++ b/src/neighbor/infrastructure/handler/neighbor.handler.ts
@@ -5,6 +5,7 @@ import DateUtils from '../../../shared/utils/date.util'
 import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
 import { GetPaginationParams, GetURLParams } from '../../../shared/utils/http.request.util'
 import FindByEmailUseCase from '../../aplication/usecases/find-by-email.usecase'
+import FindNeighborByIDUseCase from '../../aplication/usecases/find-by-id.usecase'
 import ListNeighborsUseCase from '../../aplication/usecases/list.usecase'
 import LoginNeighborUseCase from '../../aplication/usecases/login.usecase'
 import RegisterNeighborUseCase from '../../aplication/usecases/register.usecase'
@@ -15,7 +16,6 @@ import CheckIdDTO from '../dtos/check-id.dto'
 import RegisterNeighborDTO from '../dtos/register-neighbor.dto'
 import UpdateNeighborDTO from '../dtos/update-neighbor.dto'
 import SchemaValidator from '../middlewares/zod-schema-validator.middleware'
-import FindNeighborByIDUseCase from '../../aplication/usecases/find-by-id.usecase'
 
 class NeighborHandler {
   constructor(

--- a/src/neighbor/infrastructure/handler/neighbor.handler.ts
+++ b/src/neighbor/infrastructure/handler/neighbor.handler.ts
@@ -23,6 +23,22 @@ class NeighborHandler {
     this.repository = repository
   }
 
+  async findById(req: FastifyRequest<{ Params: Record<string, string> }>, rep: FastifyReply): Promise<void> {
+    try {
+      const id = GetURLParams(req, 'id')
+
+      const validateIDSchema = new SchemaValidator(CheckIdDTO, { id })
+      validateIDSchema.exec()
+
+      const findNeighbor = new FindByEmailUseCase(this.repository)
+      const neighbor = await findNeighbor.exec(id)
+
+      HandleHTTPResponse.OK(rep, 'Neighbor retrieved successfully', neighbor)
+    } catch (error) {
+      rep.status(500).send(error)
+    }
+  }
+
   async register(req: FastifyRequest, rep: FastifyReply): Promise<void> {
     try {
       const validateRegisterNeighborSchema = new SchemaValidator(RegisterNeighborDTO, req.body as NeighborPayload)

--- a/src/neighbor/infrastructure/handler/neighbor.handler.ts
+++ b/src/neighbor/infrastructure/handler/neighbor.handler.ts
@@ -5,6 +5,7 @@ import DateUtils from '../../../shared/utils/date.util'
 import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
 import { GetPaginationParams, GetURLParams } from '../../../shared/utils/http.request.util'
 import FindByEmailUseCase from '../../aplication/usecases/find-by-email.usecase'
+import ListNeighborsUseCase from '../../aplication/usecases/list.usecase'
 import LoginNeighborUseCase from '../../aplication/usecases/login.usecase'
 import RegisterNeighborUseCase from '../../aplication/usecases/register.usecase'
 import UpdateNeighborUseCase from '../../aplication/usecases/update.usecase'
@@ -14,7 +15,7 @@ import CheckIdDTO from '../dtos/check-id.dto'
 import RegisterNeighborDTO from '../dtos/register-neighbor.dto'
 import UpdateNeighborDTO from '../dtos/update-neighbor.dto'
 import SchemaValidator from '../middlewares/zod-schema-validator.middleware'
-import ListNeighborsUseCase from '../../aplication/usecases/list.usecase'
+import FindNeighborByIDUseCase from '../../aplication/usecases/find-by-id.usecase'
 
 class NeighborHandler {
   constructor(
@@ -42,7 +43,7 @@ class NeighborHandler {
       const validateIDSchema = new SchemaValidator(CheckIdDTO, { id })
       validateIDSchema.exec()
 
-      const findNeighbor = new FindByEmailUseCase(this.repository)
+      const findNeighbor = new FindNeighborByIDUseCase(this.repository)
       const neighbor = await findNeighbor.exec(id)
 
       HandleHTTPResponse.OK(rep, 'Neighbor retrieved successfully', neighbor)

--- a/src/neighbor/infrastructure/routes/neighbor.route.ts
+++ b/src/neighbor/infrastructure/routes/neighbor.route.ts
@@ -9,6 +9,12 @@ class NeighborRoute {
   ) {}
 
   setupRoutes(): void {
+    this.router.get('/api/neighbor', async (req: FastifyRequest<{ Querystring: Record<string, string> }>, rep) => {
+      await this.handler.list(req, rep)
+    })
+    this.router.get('/api/neighbor/:id', async (req: FastifyRequest<{ Params: { id: string } }>, rep) => {
+      await this.handler.findById(req, rep)
+    })
     this.router.post('/api/neighbor/auth/login', async (req, rep) => {
       await this.handler.login(req, rep)
     })


### PR DESCRIPTION
# Se agregaron los endpoints para buscar por ID y para obtener todos los vecinos

Buscar por ID:

- endpoint: `/api/neighbor/{:id}`

Obtener todos:

- endpoint: `/api/neighbor/`
