### PR TITLE
fix(docker): trim build context and fix pnpm allowBuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Dependencies (reinstalled inside the image)
+node_modules
+
+# Build artifacts (rebuilt by `pnpm build`)
+dist
+coverage
+.tsbuildinfo
+
+# Version control & CI
+.git
+.github
+.husky
+
+# Editor / IDE
+.idea
+.vscode
+
+# Local / scratch
+temp
+notes
+docs
+
+# Secrets & env (never ship into the image)
+.env
+*.env
+!.env.example
+
+# Docker & tooling (not needed inside the image)
+Dockerfile
+.dockerignore
+docker-compose.yml
+Makefile
+.atl
+
+# Docs
+README*.md
+
+# Logs
+*.log
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 # Install pnpm globally
 RUN npm install -g pnpm@11
 
-COPY --chown=node:node package.json pnpm-lock.yaml ./
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies
 RUN pnpm install
@@ -29,6 +29,7 @@ WORKDIR /usr/src/app
 # Copy only the necessary files from the builder stage
 COPY --chown=node:node --from=builder /usr/src/app/package.json \
   /usr/src/app/pnpm-lock.yaml \
+  /usr/src/app/pnpm-workspace.yaml \
   /usr/src/app/tsconfig.json ./
 COPY --chown=node:node --from=builder /usr/src/app/dist ./dist
 


### PR DESCRIPTION
Add a real .dockerignore so 'COPY . .' no longer ships node_modules, dist, .git and coverage into the build context (~256MB), drastically slowing Railway builds.

Copy pnpm-workspace.yaml before pnpm install in both stages so build-script settings for argon2/bcrypt/esbuild apply and native deps compile correctly.