### PR TITLE
feat: add production bootstrap seeder and fix username validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,14 +45,13 @@ EMAIL_APP_PASSWORD="<your-email-app-password>"
 # En dev/test, si se omite, usa 'localhost,127.0.0.1' por defecto.
 CORS_ALLOWED_ORIGINS=localhost,127.0.0.1
 
-
-
-
-
-    CI_DATABASE_PASS — usado como POSTGRES_PASSWORD para el servicio postgres (éste fue el que provocó el fallo).
-    CI_TEST_DATABASE_PASS — usado como TEST_DATABASE_PASS para las pruebas.
-    CI_ACCESS_TOKEN — used en ACCESS_TOKEN.
-    CI_REFRESH_TOKEN — used in REFRESH_TOKEN.
-    CI_RECAPTCHA_KEY — used in RECAPTCHA_SECRET_KEY.
-    CI_EMAIL_PASS — used in EMAIL_APP_PASSWORD.
-    CI_ADMIN_PASSWORD — used en ADMIN_PASSWORD.
+# ######## PRODUCTION BOOTSTRAP ######## #
+# Datos de la entidad inicial que se crea al primer deploy en producción.
+# Todos opcionales — si se omiten se usan defaults sensibles.
+PROD_ENTITY_NAME=Administración
+PROD_ENTITY_EMAIL=admin@greenbin.com
+PROD_ENTITY_DESCRIPTION=Entidad inicial del sistema
+PROD_ENTITY_CITY=Ciudad
+PROD_ENTITY_PROVINCE=Provincia
+PROD_ENTITY_LAT=-31.42
+PROD_ENTITY_LNG=-62.08

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     env_file:
       - .env
     environment:
+      NODE_ENV: development
       DATABASE_HOST: database
+      DATABASE_PORT: 5432
     networks:
       - dev-network
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import bootstrapPasswordReset from './auth/password-reset.bootstrap'
 import bootstrapSuperadmin from './superadmin/superadmin.bootstrap'
 import errorMiddleware from './shared/infrastructure/middlewares/error.middleware'
 import runSeeders from './shared/database/seeders/database.seeder'
+import seedProduction from './shared/database/seeders/production.seeder'
 
 async function bootstrapApp(port: number, options?: Options): Promise<{ app: FastifyInstance; db: Services }> {
   const db = await initMikroORM(options)
@@ -38,6 +39,10 @@ async function bootstrapApp(port: number, options?: Options): Promise<{ app: Fas
 
   if (EnvVar.server.nodeEnv === 'development') {
     await runSeeders(db.em)
+  }
+
+  if (EnvVar.server.nodeEnv === 'production') {
+    await seedProduction(db.em)
   }
   const fastify = new FastifyConifg(EnvVar.server.nodeEnv)
   const app = fastify.server

--- a/src/neighbor/infrastructure/dtos/dto-types/dto-types.ts
+++ b/src/neighbor/infrastructure/dtos/dto-types/dto-types.ts
@@ -20,7 +20,7 @@ export const usernameDTO = z
   .string()
   .min(4, { message: 'Username must be at least 4 characters long' })
   .max(100, { message: 'Username must be less than 100 characters' })
-  .regex(/^[a-zA-Z0-9]+$/, { message: 'Username must only contain letters and numbers' })
+  .regex(/^[a-zA-Z0-9_]+$/, { message: 'Username must only contain letters, numbers and underscores' })
   .refine((username: string) => username.trim().length > 0, { message: 'Username cannot be empty' })
 
 export const emailDTO = z

--- a/src/shared/config/env-var.config.ts
+++ b/src/shared/config/env-var.config.ts
@@ -42,6 +42,16 @@ interface AdminConfig {
   password: string
 }
 
+interface ProdEntityConfig {
+  name: string
+  email: string
+  description: string
+  city: string
+  province: string
+  latitude: number
+  longitude: number
+}
+
 interface Config {
   auth: Auth
   server: ServerConfig
@@ -51,6 +61,7 @@ interface Config {
   email: EmailConfig
   cors: CorsConfig
   admin: AdminConfig
+  prodEntity: ProdEntityConfig
 }
 
 const serverConfig: ServerConfig = {
@@ -120,6 +131,19 @@ const adminConfig: AdminConfig = {
   password: env.get('ADMIN_PASSWORD').required().asString()
 }
 
+// Entity config for production bootstrap. All have sensible defaults so the admin
+// can log in and update entity details later via the API. Only override if you
+// need a specific entity name or location from the first deploy.
+const prodEntityConfig: ProdEntityConfig = {
+  name: env.get('PROD_ENTITY_NAME').default('Administración').asString(),
+  email: env.get('PROD_ENTITY_EMAIL').default(adminConfig.email).asString(),
+  description: env.get('PROD_ENTITY_DESCRIPTION').default('Entidad inicial del sistema').asString(),
+  city: env.get('PROD_ENTITY_CITY').default('Ciudad').asString(),
+  province: env.get('PROD_ENTITY_PROVINCE').default('Provincia').asString(),
+  latitude: env.get('PROD_ENTITY_LAT').default('-31.42').asFloat(),
+  longitude: env.get('PROD_ENTITY_LNG').default('-62.08').asFloat()
+}
+
 const EnvVar: Config = {
   auth: authConfig,
   server: serverConfig,
@@ -128,7 +152,8 @@ const EnvVar: Config = {
   recaptcha: recaptchaConfig,
   email: emailConfig,
   cors: corsConfig,
-  admin: adminConfig
+  admin: adminConfig,
+  prodEntity: prodEntityConfig
 }
 
 export default EnvVar

--- a/src/shared/database/seeders/production.seeder.ts
+++ b/src/shared/database/seeders/production.seeder.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+import { type EntityManager } from '@mikro-orm/postgresql'
+import EntityEntity from '../../../entity/domain/entities/entity.entity'
+import ResponsibleEntity from '../../../responsible/domain/entities/responsible.entity'
+import { Roles } from '../../../auth/domain/entities/role'
+import EnvVar from '../../config/env-var.config'
+
+/**
+ * Production bootstrap seeder.
+ *
+ * Crea la entidad inicial y el superadmin cuando la base está vacía.
+ * Solo corre en producción (y solo una vez, porque es idempotente).
+ *
+ * Flujo:
+ *   1. Si no existe ninguna entidad → crea una con datos de env vars (o defaults)
+ *   2. Si no existe ningún admin → crea un Responsible con role ADMIN
+ *
+ * El admin usa ADMIN_EMAIL / ADMIN_PASSWORD del environment, obligatorios.
+ * La entidad usa PROD_ENTITY_* vars con defaults sensibles.
+ */
+async function seedProduction(em: EntityManager): Promise<void> {
+  const start = Date.now()
+  console.log('\n🚀 Inicializando bootstrap de producción...\n')
+
+  try {
+    // ── 1. Entity ──────────────────────────────────────────────────────
+    let entity: EntityEntity | null = null
+    const entityCount = await em.count(EntityEntity)
+
+    if (entityCount === 0) {
+      entity = new EntityEntity({
+        name: EnvVar.prodEntity.name,
+        email: EnvVar.prodEntity.email,
+        description: EnvVar.prodEntity.description,
+        password: EnvVar.admin.password,
+        city: EnvVar.prodEntity.city,
+        province: EnvVar.prodEntity.province,
+        coordinates: {
+          latitude: EnvVar.prodEntity.latitude,
+          longitude: EnvVar.prodEntity.longitude
+        }
+      })
+
+      await em.persistAndFlush(entity)
+      console.log(`[Bootstrap] Entidad creada: "${entity.name}" (${entity.email})`)
+    } else {
+      console.log(`[Bootstrap] Entidad: ya existen ${entityCount} registros, se omite.`)
+    }
+
+    // ── 2. Admin (Responsible + role ADMIN) ────────────────────────────
+    const adminCount = await em.count(ResponsibleEntity, { role: Roles.ADMIN })
+
+    if (adminCount === 0) {
+      // Necesitamos la entidad de referencia
+      if (entity == null) {
+        entity = await em.findOneOrFail(EntityEntity, {})
+      }
+
+      const admin = new ResponsibleEntity(
+        {
+          firstname: 'Super',
+          lastname: 'Admin',
+          username: 'superadmin',
+          email: EnvVar.admin.email,
+          password: EnvVar.admin.password,
+          dni: 99999999,
+          phoneNumber: '000-000000',
+          entityId: entity.id
+        },
+        entity
+      )
+      admin.role = Roles.ADMIN
+
+      await em.persistAndFlush(admin)
+      console.log(`[Bootstrap] Admin creado: "${admin.username}" (${admin.email})`)
+    } else {
+      console.log(`[Bootstrap] Admin: ya existen ${adminCount} registros, se omite.`)
+    }
+
+    const elapsed = ((Date.now() - start) / 1000).toFixed(2)
+    console.log(`\n✅ Bootstrap de producción completado en ${elapsed}s\n`)
+  } catch (err) {
+    console.error('\n❌ Error durante bootstrap de producción:', err)
+    throw err
+  }
+}
+
+export default seedProduction


### PR DESCRIPTION
- Add production.seeder.ts: creates initial entity + admin on first deploy
- Wire production seeder into app.ts for NODE_ENV=production
- Add ProdEntityConfig to env-var.config.ts with PROD_ENTITY_* vars
- Update .env.example with production bootstrap docs (cleanup leftover CI notes)
- Fix usernameDTO regex to allow underscores (seed usernames like malvarez_et)
- Add NODE_ENV and DATABASE_PORT to docker-compose.yml