### PR TITLE
feat(auth): verify email via OTP before creating neighbor and reward-…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import bootstrapWasteTransaction from './waste-transaction/waste-transaction.boo
 import bootstrapWaste from './waste/waste.bootstrap'
 import bootstrapStatistics from './statistics/statistics.bootstrap'
 import bootstrapPasswordReset from './auth/password-reset.bootstrap'
+import bootstrapRegisterVerification from './auth/register-verification.bootstrap'
 import bootstrapSuperadmin from './superadmin/superadmin.bootstrap'
 import errorMiddleware from './shared/infrastructure/middlewares/error.middleware'
 import runSeeders from './shared/database/seeders/database.seeder'
@@ -90,6 +91,7 @@ async function bootstrapApp(port: number, options?: Options): Promise<{ app: Fas
   bootstrapCouponTransaction(app)
   bootstrapStatistics(app)
   bootstrapPasswordReset(app)
+  bootstrapRegisterVerification(app)
   await bootstrapSuperadmin(app)
 
   app.setErrorHandler(errorMiddleware)

--- a/src/auth/application/service/email.service.ts
+++ b/src/auth/application/service/email.service.ts
@@ -34,6 +34,26 @@ class EmailService {
     })
   }
 
+  async sendRegistrationOtp(to: string, otp: string): Promise<void> {
+    await this.transporter.sendMail({
+      from: `"GreenBin" <${EnvVar.email.user}>`,
+      to,
+      subject: 'Verificá tu cuenta de GreenBin',
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto;">
+          <h2 style="color: #4caf50;">GreenBin</h2>
+          <p>¡Bienvenido/a! Estás a un paso de crear tu cuenta.</p>
+          <p>Para verificar tu correo, ingresá este código:</p>
+          <div style="font-size: 36px; font-weight: bold; letter-spacing: 8px; color: #4caf50; text-align: center; padding: 20px 0;">
+            ${otp}
+          </div>
+          <p>Este código expira en <strong>10 minutos</strong>.</p>
+          <p>Si no intentaste registrarte, ignorá este email.</p>
+        </div>
+      `
+    })
+  }
+
   async sendWasteDeliveryConfirmation(
     to: string,
     neighborName: string,

--- a/src/auth/infrastructure/handlers/register-verification.handler.ts
+++ b/src/auth/infrastructure/handlers/register-verification.handler.ts
@@ -1,0 +1,50 @@
+import { type FastifyReply, type FastifyRequest } from 'fastify'
+import EmailService from '../../application/service/email.service'
+import OtpService from '../../application/service/otp.service'
+import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
+import type NeighborRepository from '../../../neighbor/domain/repositories/neighbor.repository'
+import type RewardPartnerRepository from '../../../reward-partner/domain/repositories/reward-partner.repository'
+
+type RegistrableUserType = 'neighbor' | 'reward-partner'
+
+class RegisterVerificationHandler {
+  private readonly emailService: EmailService
+  private readonly otpService: OtpService
+
+  constructor(
+    private readonly neighborRepository: NeighborRepository,
+    private readonly rewardPartnerRepository: RewardPartnerRepository
+  ) {
+    this.emailService = new EmailService()
+    this.otpService = new OtpService()
+  }
+
+  async requestOtp(req: FastifyRequest, rep: FastifyReply): Promise<void> {
+    const { email, userType } = req.body as { email: string; userType: RegistrableUserType }
+
+    if (!email || (userType !== 'neighbor' && userType !== 'reward-partner')) {
+      HandleHTTPResponse.BadRequest(rep, 'Email y tipo de usuario son requeridos')
+      return
+    }
+
+    const alreadyExists = await this.userExistsByEmail(email, userType)
+    if (alreadyExists) {
+      HandleHTTPResponse.BadRequest(rep, 'Ese email ya está registrado')
+      return
+    }
+
+    const otp = this.otpService.generate()
+    const registerToken = this.otpService.createToken(email, otp, userType)
+
+    await this.emailService.sendRegistrationOtp(email, otp)
+
+    HandleHTTPResponse.OK(rep, 'Código enviado al correo', { registerToken })
+  }
+
+  private async userExistsByEmail(email: string, userType: RegistrableUserType): Promise<boolean> {
+    if (userType === 'neighbor') return (await this.neighborRepository.find({ email })) != null
+    return (await this.rewardPartnerRepository.find({ email })) != null
+  }
+}
+
+export default RegisterVerificationHandler

--- a/src/auth/infrastructure/routes/register-verification.route.ts
+++ b/src/auth/infrastructure/routes/register-verification.route.ts
@@ -1,0 +1,17 @@
+import { type FastifyInstance } from 'fastify'
+import type RegisterVerificationHandler from '../handlers/register-verification.handler'
+
+class RegisterVerificationRoute {
+  constructor(
+    private readonly server: FastifyInstance,
+    private readonly handler: RegisterVerificationHandler
+  ) {}
+
+  setupRoutes(): void {
+    this.server.post('/api/auth/register/request-otp', async (req, rep) => {
+      await this.handler.requestOtp(req, rep)
+    })
+  }
+}
+
+export default RegisterVerificationRoute

--- a/src/auth/register-verification.bootstrap.ts
+++ b/src/auth/register-verification.bootstrap.ts
@@ -1,0 +1,17 @@
+import { type FastifyInstance } from 'fastify'
+import NeighborMikroORMRepository from '../neighbor/infrastructure/repositories/mikro-orm/neighbor.mikroorm.repository'
+import RewardPartnerMikroORMRepository from '../reward-partner/infrastructure/repositories/mikro-orm/reward-partner.mikroorm.repository'
+import RegisterVerificationHandler from './infrastructure/handlers/register-verification.handler'
+import RegisterVerificationRoute from './infrastructure/routes/register-verification.route'
+
+function bootstrapRegisterVerification(app: FastifyInstance): void {
+  const neighborRepository = new NeighborMikroORMRepository()
+  const rewardPartnerRepository = new RewardPartnerMikroORMRepository()
+
+  const handler = new RegisterVerificationHandler(neighborRepository, rewardPartnerRepository)
+
+  const routes = new RegisterVerificationRoute(app, handler)
+  routes.setupRoutes()
+}
+
+export default bootstrapRegisterVerification

--- a/src/neighbor/infrastructure/handlers/neighbor.handler.ts
+++ b/src/neighbor/infrastructure/handlers/neighbor.handler.ts
@@ -1,5 +1,6 @@
 import { type FastifyReply, type FastifyRequest } from 'fastify'
 import AuthService from '../../../auth/application/service/auth.service'
+import OtpService from '../../../auth/application/service/otp.service'
 import RecaptchaService from '../../../auth/application/service/recaptcha.service'
 import { Roles } from '../../../auth/domain/entities/role'
 import type IJWTStrategy from '../../../auth/domain/strategies/jwt.interface.strategy'
@@ -65,14 +66,31 @@ class NeighborHandler {
   }
 
   async register(req: FastifyRequest<{ Body: NeighborPayload }>, rep: FastifyReply): Promise<void> {
-    const validateRegisterNeighborSchema = new NeighborSchemaValidator(RegisterNeighborDTO, req.body)
+    const { registerToken, otp, ...payload } = req.body as NeighborPayload & {
+      registerToken: string
+      otp: string
+    }
+
+    const otpService = new OtpService()
+    try {
+      const otpPayload = otpService.verify(registerToken, otp)
+      if (otpPayload.email !== payload.email || otpPayload.userType !== 'neighbor') {
+        HandleHTTPResponse.BadRequest(rep, 'El código no corresponde a este email')
+        return
+      }
+    } catch {
+      HandleHTTPResponse.BadRequest(rep, 'Código de verificación inválido o expirado')
+      return
+    }
+
+    const validateRegisterNeighborSchema = new NeighborSchemaValidator(RegisterNeighborDTO, payload)
     validateRegisterNeighborSchema.exec()
 
     const registerNeighbor = new RegisterNeighborUseCase(
       this.neighborRepository,
       new FindEntityByIDUseCase(this.entityRepository)
     )
-    const neighbor = await registerNeighbor.exec(req.body)
+    const neighbor = await registerNeighbor.exec(payload)
 
     const authService = new AuthService(this.jwtStrategy)
     const accessToken = await authService.generateAccessToken(neighbor.id, {

--- a/src/neighbor/test/neighbor.test.ts
+++ b/src/neighbor/test/neighbor.test.ts
@@ -8,6 +8,7 @@ import {
   createWasteCategory,
   createResponsible,
   createGreenPoint,
+  requestRegisterOtp,
   NEIGHBOR_FIXTURE
 } from '../../shared/test/test-helpers'
 
@@ -26,10 +27,19 @@ describe('Neighbor — integration tests', () => {
 
   describe('POST /api/neighbor', () => {
     it('crea un vecino vinculado a una entidad existente', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'nuevo@test.com', 'neighbor')
       const res = await app.inject({
         method: 'POST',
         url: '/api/neighbor',
-        body: { ...NEIGHBOR_FIXTURE, username: 'nuevo', email: 'nuevo@test.com', dni: 30000099, entityId }
+        body: {
+          ...NEIGHBOR_FIXTURE,
+          username: 'nuevo',
+          email: 'nuevo@test.com',
+          dni: 30000099,
+          entityId,
+          registerToken,
+          otp
+        }
       })
       expect(res.statusCode).toBe(201)
       const body = res.json()
@@ -38,6 +48,7 @@ describe('Neighbor — integration tests', () => {
     })
 
     it('devuelve 404 con entityId inexistente', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'nuevo2@test.com', 'neighbor')
       const res = await app.inject({
         method: 'POST',
         url: '/api/neighbor',
@@ -46,31 +57,35 @@ describe('Neighbor — integration tests', () => {
           username: 'nuevo2',
           email: 'nuevo2@test.com',
           dni: 30000098,
-          entityId: '00000000-0000-0000-0000-000000000000'
+          entityId: '00000000-0000-0000-0000-000000000000',
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(404)
     })
 
     it('devuelve 409 con username duplicado', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'otro@test.com', 'neighbor')
       const res = await app.inject({
         method: 'POST',
         url: '/api/neighbor',
-        body: { ...NEIGHBOR_FIXTURE, email: 'otro@test.com', entityId }
+        body: { ...NEIGHBOR_FIXTURE, email: 'otro@test.com', entityId, registerToken, otp }
       })
       expect(res.statusCode).toBe(409)
     })
 
-    it('devuelve 409 con email duplicado', async () => {
+    it('no permite pedir OTP de registro con email ya registrado', async () => {
       const res = await app.inject({
         method: 'POST',
-        url: '/api/neighbor',
-        body: { ...NEIGHBOR_FIXTURE, username: 'otrousuario', entityId }
+        url: '/api/auth/register/request-otp',
+        body: { email: NEIGHBOR_FIXTURE.email, userType: 'neighbor' }
       })
-      expect(res.statusCode).toBe(409)
+      expect(res.statusCode).toBe(400)
     })
 
     it('devuelve 400 con fecha de nacimiento inválida', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'nuevo3@test.com', 'neighbor')
       const res = await app.inject({
         method: 'POST',
         url: '/api/neighbor',
@@ -80,7 +95,9 @@ describe('Neighbor — integration tests', () => {
           email: 'nuevo3@test.com',
           dni: 30000097,
           birthdate: '1990-05-14',
-          entityId
+          entityId,
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(400)

--- a/src/reward-partner/infrastructure/handlers/reward-partner.handler.ts
+++ b/src/reward-partner/infrastructure/handlers/reward-partner.handler.ts
@@ -1,5 +1,6 @@
 import { type FastifyReply, type FastifyRequest } from 'fastify'
 import AuthService from '../../../auth/application/service/auth.service'
+import OtpService from '../../../auth/application/service/otp.service'
 import RecaptchaService from '../../../auth/application/service/recaptcha.service'
 import { Roles } from '../../../auth/domain/entities/role'
 import type IJWTStrategy from '../../../auth/domain/strategies/jwt.interface.strategy'
@@ -43,7 +44,22 @@ class RewardPartnerHandler {
   }
 
   async register(req: FastifyRequest, rep: FastifyReply): Promise<void> {
-    const payload: RewardPartnerPayload = req.body as RewardPartnerPayload
+    const { registerToken, otp, ...payload } = req.body as RewardPartnerPayload & {
+      registerToken: string
+      otp: string
+    }
+
+    const otpService = new OtpService()
+    try {
+      const otpPayload = otpService.verify(registerToken, otp)
+      if (otpPayload.email !== payload.email || otpPayload.userType !== 'reward-partner') {
+        HandleHTTPResponse.BadRequest(rep, 'El código no corresponde a este email')
+        return
+      }
+    } catch {
+      HandleHTTPResponse.BadRequest(rep, 'Código de verificación inválido o expirado')
+      return
+    }
 
     const validateRegisterRewardPartnerSchema = new RewardPartnerSchemaValidator(RegisterRewardPartnerDTO, payload)
     validateRegisterRewardPartnerSchema.exec()

--- a/src/reward-partner/test/reward-partner.test.ts
+++ b/src/reward-partner/test/reward-partner.test.ts
@@ -5,6 +5,7 @@ import {
   createEntityWithToken,
   createRewardPartner,
   createRewardPartnerWithToken,
+  requestRegisterOtp,
   REWARD_PARTNER_FIXTURE
 } from '../../shared/test/test-helpers'
 
@@ -29,6 +30,7 @@ describe('RewardPartner — integration tests', () => {
 
   describe('POST /api/reward-partner', () => {
     it('crea un local adherido vinculado a una entidad existente', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'nuevopart@test.com', 'reward-partner')
       const res = await app.inject({
         method: 'POST',
         url: '/api/reward-partner',
@@ -40,7 +42,9 @@ describe('RewardPartner — integration tests', () => {
           name: 'Nuevo Local',
           entityId,
           cuit: '20123456789',
-          coordinates: { latitude: -32.41, longitude: -63.24 }
+          coordinates: { latitude: -32.41, longitude: -63.24 },
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(201)
@@ -59,6 +63,7 @@ describe('RewardPartner — integration tests', () => {
     })
 
     it('devuelve 404 con entityId inexistente', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'noentpart@test.com', 'reward-partner')
       const res = await app.inject({
         method: 'POST',
         url: '/api/reward-partner',
@@ -70,7 +75,9 @@ describe('RewardPartner — integration tests', () => {
           name: 'No Ent Local',
           entityId: '00000000-0000-0000-0000-000000000000',
           cuit: '20234567891',
-          coordinates: { latitude: -32.415, longitude: -63.245 }
+          coordinates: { latitude: -32.415, longitude: -63.245 },
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(404)
@@ -89,6 +96,7 @@ describe('RewardPartner — integration tests', () => {
         },
         entityToken
       )
+      const { registerToken, otp } = await requestRegisterOtp(app, 'duppart2@test.com', 'reward-partner')
       const res = await app.inject({
         method: 'POST',
         url: '/api/reward-partner',
@@ -100,13 +108,16 @@ describe('RewardPartner — integration tests', () => {
           name: 'Dup Local 2',
           entityId,
           cuit: '20345678912',
-          coordinates: { latitude: -32.425, longitude: -63.255 }
+          coordinates: { latitude: -32.425, longitude: -63.255 },
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(409)
     })
 
     it('devuelve 400 con CUIT con formato inválido', async () => {
+      const { registerToken, otp } = await requestRegisterOtp(app, 'cuitpart@test.com', 'reward-partner')
       const res = await app.inject({
         method: 'POST',
         url: '/api/reward-partner',
@@ -118,7 +129,9 @@ describe('RewardPartner — integration tests', () => {
           name: 'Cuit Local',
           entityId,
           cuit: '123',
-          coordinates: { latitude: -32.43, longitude: -63.26 }
+          coordinates: { latitude: -32.43, longitude: -63.26 },
+          registerToken,
+          otp
         }
       })
       expect(res.statusCode).toBe(400)

--- a/src/shared/test/test-helpers.ts
+++ b/src/shared/test/test-helpers.ts
@@ -1,4 +1,5 @@
 import { type FastifyInstance } from 'fastify'
+import jwt from 'jsonwebtoken'
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -93,6 +94,24 @@ function authHeaders(token?: string): Record<string, string> {
   return token != null && token.length > 0 ? { authorization: `Bearer ${token}` } : {}
 }
 
+// Pide un OTP de registro y lo extrae del JWT devuelto (nodemailer está mockeado
+// en test.setup, así que no se envía correo real). Permite testear el alta que
+// ahora exige verificación por mail.
+export async function requestRegisterOtp(
+  app: FastifyInstance,
+  email: string,
+  userType: 'neighbor' | 'reward-partner'
+): Promise<{ registerToken: string; otp: string }> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/auth/register/request-otp',
+    body: { email, userType }
+  })
+  const { registerToken } = res.json().data as { registerToken: string }
+  const payload = jwt.decode(registerToken) as { otp: string }
+  return { registerToken, otp: payload.otp }
+}
+
 export async function createEntity(app: FastifyInstance, overrides = {}): Promise<Record<string, string>> {
   const res = await app.inject({
     method: 'POST',
@@ -131,10 +150,12 @@ export async function createNeighbor(
   entityId: string,
   overrides = {}
 ): Promise<Record<string, string>> {
+  const body = { ...NEIGHBOR_FIXTURE, entityId, ...overrides }
+  const { registerToken, otp } = await requestRegisterOtp(app, body.email, 'neighbor')
   const res = await app.inject({
     method: 'POST',
     url: '/api/neighbor',
-    body: { ...NEIGHBOR_FIXTURE, entityId, ...overrides }
+    body: { ...body, registerToken, otp }
   })
   return res.json().data
 }
@@ -172,11 +193,13 @@ export async function createRewardPartner(
   overrides = {},
   token?: string
 ): Promise<Record<string, string>> {
+  const body = { ...REWARD_PARTNER_FIXTURE, entityId, ...overrides }
+  const { registerToken, otp } = await requestRegisterOtp(app, body.email, 'reward-partner')
   const res = await app.inject({
     method: 'POST',
     url: '/api/reward-partner',
     headers: authHeaders(token),
-    body: { ...REWARD_PARTNER_FIXTURE, entityId, ...overrides }
+    body: { ...body, registerToken, otp }
   })
   if (res.statusCode >= 400) {
     throw new Error(`Failed to create reward partner: ${res.statusCode} - ${res.body}`)


### PR DESCRIPTION
…partner

Stateless OTP email-verification on public registration, mirroring the password-reset flow (no DB migration):

- POST /api/auth/register/request-otp: checks the email is free, generates an OTP, signs a 10m JWT and emails it
- neighbor and reward-partner register() require { registerToken, otp } and verify them (email + userType) before creating the account
- EmailService.sendRegistrationOtp for the verification email
- test helpers and register tests updated for the two-step flow