### PR TITLE
feat(notification): agregar push notifications web y actualizaciones …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,7 @@ PROD_ENTITY_CITY=Ciudad
 PROD_ENTITY_PROVINCE=Provincia
 PROD_ENTITY_LAT=-31.42
 PROD_ENTITY_LNG=-62.08
+
+# ######### VAPID SETTINGS ########### #
+VAPID_PUBLIC_KEY=<your-public-key>
+VAPID_PRIVATE_KEY=<your-private-key>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,4 +113,6 @@ jobs:
           ADMIN_EMAIL: admin@example.com
           ADMIN_PASSWORD: test_password
           CORS_ALLOWED_ORIGINS: localhost
+          VAPID_PUBLIC_KEY: BPyuXIbz0QLLjqa5GK1HRVqMoEU7y3VFV6JPC27UMtsnUJpDr6Wdpa5M0TqBQp2hfgo0xAJqrq2EAoX33iND-Yw
+          VAPID_PRIVATE_KEY: n5hwwYRl4VU-ixEiLZlkITQ1QP3VvhzaHCQVtJ366VY
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/node": "20.10.5",
     "@types/nodemailer": "8.0.0",
     "@types/uuid": "9.0.7",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "6.14.0",
     "@vitest/coverage-v8": "2.0.5",
     "@vitest/ui": "2.0.5",
@@ -77,6 +78,7 @@
     "reflect-metadata": "0.2.2",
     "rimraf": "5.0.5",
     "uuid": "9.0.1",
+    "web-push": "^3.6.7",
     "zod": "3.22.4"
   },
   "packageManager": "pnpm@11.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       uuid:
         specifier: 9.0.1
         version: 9.0.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: 3.22.4
         version: 3.22.4
@@ -106,6 +109,9 @@ importers:
       '@types/uuid':
         specifier: 9.0.7
         version: 9.0.7
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@typescript-eslint/eslint-plugin':
         specifier: 6.14.0
         version: 6.14.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0(supports-color@5.5.0))(typescript@5.3.3))(eslint@8.56.0(supports-color@5.5.0))(typescript@5.3.3)
@@ -765,6 +771,9 @@ packages:
   '@types/uuid@9.0.7':
     resolution: {integrity: sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@6.14.0':
     resolution: {integrity: sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -886,6 +895,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -1011,6 +1024,9 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1055,6 +1071,9 @@ packages:
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
   bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -1983,9 +2002,17 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2573,6 +2600,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3126,6 +3156,9 @@ packages:
     resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
@@ -3657,6 +3690,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4392,6 +4430,10 @@ snapshots:
 
   '@types/uuid@9.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.10.5
+
   '@typescript-eslint/eslint-plugin@6.14.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0(supports-color@5.5.0))(typescript@5.3.3))(eslint@8.56.0(supports-color@5.5.0))(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
@@ -4568,6 +4610,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
       ajv: 8.13.0
@@ -4717,6 +4761,13 @@ snapshots:
 
   arrify@1.0.1: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
@@ -4751,6 +4802,8 @@ snapshots:
   big-integer@1.6.52: {}
 
   binary-extensions@2.2.0: {}
+
+  bn.js@4.12.5: {}
 
   bplist-parser@0.2.0:
     dependencies:
@@ -5875,9 +5928,18 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
@@ -6437,6 +6499,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -7015,6 +7079,8 @@ snapshots:
 
   safe-stable-stringify@2.4.3: {}
 
+  safer-buffer@2.1.2: {}
+
   secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
@@ -7577,6 +7643,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 3.2.3
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@3.0.1: {}
 

--- a/src/coupon-transaction/application/usecases/redeem-coupon.usecase.ts
+++ b/src/coupon-transaction/application/usecases/redeem-coupon.usecase.ts
@@ -66,6 +66,7 @@ class RedeemCouponUseCase {
       category: NotificationCategory.COUPON_PURCHASED,
       title: 'Cupón comprado',
       body: `Compraste "${coupon.title}". Código: ${code}. Vence el ${expirationDate.toLocaleDateString('es-AR')}.`,
+      data: { transactionId: transaction.id, couponId: coupon.id },
       sendEmail: async emailService => {
         await emailService.sendCouponPurchaseConfirmation(
           neighbor.email,
@@ -75,6 +76,18 @@ class RedeemCouponUseCase {
           expirationDate
         )
       }
+    })
+
+    // Al local: que vea en vivo que le compraron el cupón, sin refrescar.
+    // Solo in-app/push por ahora (mismo patrón que register-waste-delivery
+    // usa para el responsable): no se pidió un mail para este aviso.
+    void this.notificationDispatcher.dispatch({
+      recipientId: rewardPartner.id,
+      recipientRole: Roles.REWARD_PARTNER,
+      category: NotificationCategory.COUPON_PURCHASED,
+      title: 'Cupón comprado',
+      body: `${neighbor.firstname} ${neighbor.lastname} compró "${coupon.title}".`,
+      data: { transactionId: transaction.id, couponId: coupon.id }
     })
 
     return transaction

--- a/src/coupon-transaction/test/redeem-coupon.usecase.unit.test.ts
+++ b/src/coupon-transaction/test/redeem-coupon.usecase.unit.test.ts
@@ -86,17 +86,24 @@ function makeUseCase(dispatch: ReturnType<typeof vi.fn>): RedeemCouponUseCase {
 }
 
 describe('RedeemCouponUseCase — notificaciones', () => {
-  it('dispara COUPON_PURCHASED al vecino que compró el cupón', async () => {
+  it('dispara COUPON_PURCHASED al vecino que compró el cupón y al local dueño', async () => {
     const dispatch = vi.fn()
     const useCase = makeUseCase(dispatch)
 
     await useCase.exec({ neighborId: mockNeighbor.id, couponId: mockCoupon.id })
 
-    expect(dispatch).toHaveBeenCalledTimes(1)
-    const event = dispatch.mock.calls[0][0]
-    expect(event.recipientId).toBe(mockNeighbor.id)
-    expect(event.recipientRole).toBe(Roles.NEIGHBOR)
-    expect(event.category).toBe(NotificationCategory.COUPON_PURCHASED)
-    expect(typeof event.sendEmail).toBe('function')
+    expect(dispatch).toHaveBeenCalledTimes(2)
+
+    const neighborEvent = dispatch.mock.calls[0][0]
+    expect(neighborEvent.recipientId).toBe(mockNeighbor.id)
+    expect(neighborEvent.recipientRole).toBe(Roles.NEIGHBOR)
+    expect(neighborEvent.category).toBe(NotificationCategory.COUPON_PURCHASED)
+    expect(typeof neighborEvent.sendEmail).toBe('function')
+
+    const rewardPartnerEvent = dispatch.mock.calls[1][0]
+    expect(rewardPartnerEvent.recipientId).toBe(mockRewardPartner.id)
+    expect(rewardPartnerEvent.recipientRole).toBe(Roles.REWARD_PARTNER)
+    expect(rewardPartnerEvent.category).toBe(NotificationCategory.COUPON_PURCHASED)
+    expect(rewardPartnerEvent.sendEmail).toBeUndefined()
   })
 })

--- a/src/coupon/application/usecases/register.usecase.ts
+++ b/src/coupon/application/usecases/register.usecase.ts
@@ -1,4 +1,5 @@
 import type FindRewardPartnerByIdUseCase from '../../../reward-partner/application/usecases/find-by-id.usecase'
+import type ListNeighborsUseCase from '../../../neighbor/application/usecases/list.usecase'
 import { Roles } from '../../../auth/domain/entities/role'
 import { NotificationCategory } from '../../../notification/domain/enums/notification-category.enum'
 import type NotificationDispatcher from '../../../notification/application/service/notification-dispatcher.service'
@@ -7,11 +8,17 @@ import ErrorCannotSaveCoupon from '../../domain/errors/cannot-save-coupon.error'
 import type CouponPayload from '../../domain/payloads/coupon.payload'
 import type CouponRepository from '../../domain/repositories/coupon.repository'
 
+// Limite pragmatico para el fan-out a vecinos: no hay entidades con mas
+// vecinos que esto en el alcance actual de la app. Si se necesita mas, hay
+// que paginar el fan-out en vez de subir el numero.
+const MAX_NEIGHBORS_PER_ENTITY = 10000
+
 class RegisterCouponUseCase {
   constructor(
     private readonly repository: CouponRepository,
     private readonly findRewardPartner: FindRewardPartnerByIdUseCase,
-    private readonly notificationDispatcher: NotificationDispatcher
+    private readonly notificationDispatcher: NotificationDispatcher,
+    private readonly listNeighbors: ListNeighborsUseCase
   ) {}
 
   async exec(payload: CouponPayload): Promise<CouponEntity> {
@@ -23,8 +30,7 @@ class RegisterCouponUseCase {
       throw new ErrorCannotSaveCoupon()
     }
 
-    // Unico destinatario: el local que lo creo. Nada masivo a vecinos de la
-    // entidad (decision de alcance ya tomada).
+    // Al local: confirmacion de que su cupon quedo creado.
     void this.notificationDispatcher.dispatch({
       recipientId: rewardPartner.id,
       recipientRole: Roles.REWARD_PARTNER,
@@ -35,6 +41,23 @@ class RegisterCouponUseCase {
         await emailService.sendCouponCreatedConfirmation(rewardPartner.email, rewardPartner.name, coupon.title)
       }
     })
+
+    // A cada vecino de la misma entidad: que vean el cupon nuevo en el
+    // catalogo en vivo (via SSE) sin refrescar. Deliberadamente SIN mail acá
+    // (mandarle un mail a todos los vecinos por cada cupon creado seria
+    // spam); el in-app/push que dispare el dispatcher para cada uno queda
+    // gateado por su propia preferencia de COUPON_CREATED, igual que siempre.
+    const neighbors = await this.listNeighbors.exec(0, MAX_NEIGHBORS_PER_ENTITY, rewardPartner.entity.id)
+    for (const neighbor of neighbors) {
+      void this.notificationDispatcher.dispatch({
+        recipientId: neighbor.id,
+        recipientRole: Roles.NEIGHBOR,
+        category: NotificationCategory.COUPON_CREATED,
+        title: 'Nuevo cupón disponible',
+        body: `"${coupon.title}" ya está disponible en ${rewardPartner.name}.`,
+        data: { couponId: coupon.id }
+      })
+    }
 
     return coupon
   }

--- a/src/coupon/coupon.bootstrap.ts
+++ b/src/coupon/coupon.bootstrap.ts
@@ -1,6 +1,8 @@
 import { type FastifyInstance } from 'fastify'
 import type RewardPartnerRepository from '../reward-partner/domain/repositories/reward-partner.repository'
 import RewardPartnerMikroORMRepository from '../reward-partner/infrastructure/repositories/mikro-orm/reward-partner.mikroorm.repository'
+import type NeighborRepository from '../neighbor/domain/repositories/neighbor.repository'
+import NeighborMikroORMRepository from '../neighbor/infrastructure/repositories/mikro-orm/neighbor.mikroorm.repository'
 import type CouponRepository from './domain/repositories/coupon.repository'
 import CouponHandler from './infrastructure/handlers/coupon.handler'
 import CouponMikroORMRepository from './infrastructure/repositories/mikro-orm/coupon.mikroorm.repository'
@@ -9,8 +11,9 @@ import CouponRoute from './infrastructure/routes/coupon.route'
 async function bootstrapCoupon(router: FastifyInstance): Promise<void> {
   const couponRepository: CouponRepository = new CouponMikroORMRepository()
   const rewardPartnerRepository: RewardPartnerRepository = new RewardPartnerMikroORMRepository()
+  const neighborRepository: NeighborRepository = new NeighborMikroORMRepository()
 
-  const handler = new CouponHandler(couponRepository, rewardPartnerRepository)
+  const handler = new CouponHandler(couponRepository, rewardPartnerRepository, neighborRepository)
 
   const routes = new CouponRoute(router, handler)
   routes.setupRoutes()

--- a/src/coupon/infrastructure/handlers/coupon.handler.ts
+++ b/src/coupon/infrastructure/handlers/coupon.handler.ts
@@ -1,6 +1,8 @@
 import { type FastifyReply, type FastifyRequest } from 'fastify'
 import FindRewardPartnerByIdUseCase from '../../../reward-partner/application/usecases/find-by-id.usecase'
 import type RewardPartnerRepository from '../../../reward-partner/domain/repositories/reward-partner.repository'
+import ListNeighborsUseCase from '../../../neighbor/application/usecases/list.usecase'
+import type NeighborRepository from '../../../neighbor/domain/repositories/neighbor.repository'
 import CheckIdDTO from '../../../shared/infrastructure/dto-types/check-id.dto'
 import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
 import { getPaginationParams, getURLParams } from '../../../shared/utils/http.request.util'
@@ -26,7 +28,8 @@ import createNotificationDispatcher from '../../../notification/notification-dis
 class CouponHandler {
   constructor(
     private readonly couponRepository: CouponRepository,
-    private readonly rewardPartnerRepository: RewardPartnerRepository
+    private readonly rewardPartnerRepository: RewardPartnerRepository,
+    private readonly neighborRepository: NeighborRepository
   ) {}
 
   async list(req: FastifyRequest<{ Querystring: Record<string, string> }>, rep: FastifyReply): Promise<void> {
@@ -80,10 +83,12 @@ class CouponHandler {
     }
 
     const findRewardPartner = new FindRewardPartnerByIdUseCase(this.rewardPartnerRepository)
+    const listNeighbors = new ListNeighborsUseCase(this.neighborRepository)
     const registerCoupon = new RegisterCouponUseCase(
       this.couponRepository,
       findRewardPartner,
-      createNotificationDispatcher()
+      createNotificationDispatcher(),
+      listNeighbors
     )
     const coupon = await registerCoupon.exec(req.body)
 

--- a/src/coupon/test/register.usecase.unit.test.ts
+++ b/src/coupon/test/register.usecase.unit.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest'
 import RegisterCouponUseCase from '../application/usecases/register.usecase'
 import type CouponRepository from '../domain/repositories/coupon.repository'
 import type FindRewardPartnerByIdUseCase from '../../reward-partner/application/usecases/find-by-id.usecase'
+import type ListNeighborsUseCase from '../../neighbor/application/usecases/list.usecase'
 import type NotificationDispatcher from '../../notification/application/service/notification-dispatcher.service'
 import { NotificationCategory } from '../../notification/domain/enums/notification-category.enum'
 import { Roles } from '../../auth/domain/entities/role'
 import EntityEntity from '../../entity/domain/entities/entity.entity'
 import RewardPartnerEntity from '../../reward-partner/domain/entities/reward-partner.entity'
+import NeighborEntity from '../../neighbor/domain/entities/neighbor.entity'
 import type CouponEntity from '../domain/entities/coupon.entity'
 
 const mockEntity = new EntityEntity({
@@ -34,16 +36,25 @@ const mockRewardPartner = new RewardPartnerEntity(
   mockEntity
 )
 
-function makeUseCase(dispatch: ReturnType<typeof vi.fn>): RegisterCouponUseCase {
+const mockNeighbors = [
+  new NeighborEntity('Ana', 'Gomez', 'ana', 'ana@test.com', 'p', 111, '123', new Date('1990-01-01'), mockEntity),
+  new NeighborEntity('Bruno', 'Diaz', 'bruno', 'bruno@test.com', 'p', 222, '456', new Date('1990-01-01'), mockEntity)
+]
+
+function makeUseCase(
+  dispatch: ReturnType<typeof vi.fn>,
+  neighbors: NeighborEntity[] = mockNeighbors
+): RegisterCouponUseCase {
   const repository = { save: async (coupon: CouponEntity) => coupon } as unknown as CouponRepository
   const findRewardPartner = { exec: async () => mockRewardPartner } as unknown as FindRewardPartnerByIdUseCase
   const notificationDispatcher = { dispatch } as unknown as NotificationDispatcher
+  const listNeighbors = { exec: async () => neighbors } as unknown as ListNeighborsUseCase
 
-  return new RegisterCouponUseCase(repository, findRewardPartner, notificationDispatcher)
+  return new RegisterCouponUseCase(repository, findRewardPartner, notificationDispatcher, listNeighbors)
 }
 
 describe('RegisterCouponUseCase — notificaciones', () => {
-  it('dispara COUPON_CREATED únicamente al local que creó el cupón (sin masivo a vecinos)', async () => {
+  it('dispara COUPON_CREATED al local que creó el cupón y a cada vecino de su entidad', async () => {
     const dispatch = vi.fn()
     const useCase = makeUseCase(dispatch)
 
@@ -58,12 +69,38 @@ describe('RegisterCouponUseCase — notificaciones', () => {
       rewardPartnerId: mockRewardPartner.id
     })
 
+    expect(dispatch).toHaveBeenCalledTimes(1 + mockNeighbors.length)
+
+    const rewardPartnerEvent = dispatch.mock.calls[0][0]
+    expect(rewardPartnerEvent.recipientId).toBe(mockRewardPartner.id)
+    expect(rewardPartnerEvent.recipientRole).toBe(Roles.REWARD_PARTNER)
+    expect(rewardPartnerEvent.category).toBe(NotificationCategory.COUPON_CREATED)
+
+    const neighborEvents = dispatch.mock.calls.slice(1).map(call => call[0])
+    expect(neighborEvents).toHaveLength(mockNeighbors.length)
+    neighborEvents.forEach((event, index) => {
+      expect(event.recipientId).toBe(mockNeighbors[index].id)
+      expect(event.recipientRole).toBe(Roles.NEIGHBOR)
+      expect(event.category).toBe(NotificationCategory.COUPON_CREATED)
+      expect(event.sendEmail).toBeUndefined()
+    })
+  })
+
+  it('no rompe si la entidad todavía no tiene vecinos', async () => {
+    const dispatch = vi.fn()
+    const useCase = makeUseCase(dispatch, [])
+
+    await useCase.exec({
+      title: 'Cupón nuevo',
+      description: 'desc',
+      discount: 15,
+      state: 'AVAILABLE',
+      isAvailable: true,
+      validDays: 20,
+      costInPoints: 30,
+      rewardPartnerId: mockRewardPartner.id
+    })
+
     expect(dispatch).toHaveBeenCalledTimes(1)
-    const event = dispatch.mock.calls[0][0]
-    expect(event.recipientId).toBe(mockRewardPartner.id)
-    expect(event.recipientRole).toBe(Roles.REWARD_PARTNER)
-    expect(event.category).toBe(NotificationCategory.COUPON_CREATED)
-    // Decisión de alcance confirmada: nunca se notifica al rol NEIGHBOR desde este flujo.
-    expect(event.recipientRole).not.toBe(Roles.NEIGHBOR)
   })
 })

--- a/src/migrations/Migration20260713150000.ts
+++ b/src/migrations/Migration20260713150000.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260713150000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "push_subscriptions" ("id" uuid not null, "created_at" timestamptz not null, "updated_at" timestamptz not null, "is_active" boolean not null default true, "recipient_id" varchar(255) not null, "recipient_role" text check ("recipient_role" in ('entity', 'neighbor', 'responsible', 'rewardPartner', 'admin')) not null, "endpoint" text not null, "p256dh" varchar(255) not null, "auth" varchar(255) not null, constraint "push_subscriptions_pkey" primary key ("id"));`);
+    this.addSql(`alter table "push_subscriptions" add constraint "push_subscriptions_endpoint_unique" unique ("endpoint");`);
+    this.addSql(`create index "push_subscriptions_recipient_id_recipient_role_index" on "push_subscriptions" ("recipient_id", "recipient_role");`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "push_subscriptions" cascade;`);
+  }
+
+}

--- a/src/notification/application/service/notification-dispatcher.service.ts
+++ b/src/notification/application/service/notification-dispatcher.service.ts
@@ -1,8 +1,10 @@
 import type EmailService from '../../../auth/application/service/email.service'
 import type { Roles } from '../../../auth/domain/entities/role'
 import type { NotificationCategory } from '../../domain/enums/notification-category.enum'
+import type RealtimeBroadcaster from '../../domain/services/realtime-broadcaster'
 import type FindOrCreateNotificationPreferenceUseCase from '../usecases/find-or-create-preference.usecase'
 import type RegisterNotificationUseCase from '../usecases/register.usecase'
+import type PushNotificationService from './push-notification.service'
 
 interface NotificationEvent {
   recipientId: string
@@ -10,6 +12,9 @@ interface NotificationEvent {
   category: NotificationCategory
   title: string
   body: string
+  /** Datos estructurados para consumidores en vivo (SSE): ids, montos, etc.
+   *  No se persiste ni se manda por mail, solo viaja al front conectado. */
+  data?: Record<string, unknown>
   /** Closure: cada use case decide qué método de EmailService llamar y con qué
    *  argumentos. El dispatcher no necesita conocer la firma de cada mail.
    *  Si se omite, el evento solo genera notificación in-app (sin mail). */
@@ -27,7 +32,9 @@ class NotificationDispatcher {
   constructor(
     private readonly findOrCreatePreference: FindOrCreateNotificationPreferenceUseCase,
     private readonly registerNotification: RegisterNotificationUseCase,
-    private readonly emailService: EmailService
+    private readonly emailService: EmailService,
+    private readonly pushService: PushNotificationService,
+    private readonly realtimeBroadcaster: RealtimeBroadcaster
   ) {}
 
   async dispatch(event: NotificationEvent): Promise<void> {
@@ -40,6 +47,26 @@ class NotificationDispatcher {
       await this.registerNotification.exec(event)
     } catch (error) {
       console.error('[NotificationDispatcher] no se pudo persistir la notificación in-app', error)
+    }
+
+    try {
+      await this.pushService.sendToRecipient(event.recipientId, event.recipientRole, {
+        title: event.title,
+        body: event.body
+      })
+    } catch (error) {
+      console.error('[NotificationDispatcher] no se pudo enviar el push', error)
+    }
+
+    try {
+      this.realtimeBroadcaster.send(event.recipientId, event.recipientRole, {
+        category: event.category,
+        title: event.title,
+        body: event.body,
+        data: event.data
+      })
+    } catch (error) {
+      console.error('[NotificationDispatcher] no se pudo emitir el evento en vivo', error)
     }
 
     if (event.sendEmail == null) return

--- a/src/notification/application/service/push-notification.service.ts
+++ b/src/notification/application/service/push-notification.service.ts
@@ -1,0 +1,49 @@
+import webpush from 'web-push'
+import type { Roles } from '../../../auth/domain/entities/role'
+import EnvVar from '../../../shared/config/env-var.config'
+import type PushSubscriptionRepository from '../../domain/repositories/push-subscription.repository'
+
+interface PushPayload {
+  title: string
+  body: string
+}
+
+class PushNotificationService {
+  constructor(private readonly subscriptionRepository: PushSubscriptionRepository) {
+    webpush.setVapidDetails(`mailto:${EnvVar.push.contactEmail}`, EnvVar.push.publicKey, EnvVar.push.privateKey)
+  }
+
+  async sendToRecipient(recipientId: string, recipientRole: Roles, payload: PushPayload): Promise<void> {
+    const subscriptions = await this.subscriptionRepository.findByRecipient(recipientId, recipientRole)
+
+    await Promise.all(
+      subscriptions.map(async subscription => {
+        try {
+          await webpush.sendNotification(
+            {
+              endpoint: subscription.endpoint,
+              keys: { p256dh: subscription.p256dh, auth: subscription.auth }
+            },
+            JSON.stringify({ notification: { title: payload.title, body: payload.body } })
+          )
+        } catch (error) {
+          // 404/410: el navegador invalido la suscripcion (usuario desinstalo,
+          // borro datos del sitio, etc.) -- la limpiamos para no reintentar en vano.
+          if (this.isGoneError(error)) {
+            await this.subscriptionRepository.deleteByEndpoint(subscription.endpoint)
+            return
+          }
+          console.error('[PushNotificationService] no se pudo enviar el push', error)
+        }
+      })
+    )
+  }
+
+  private isGoneError(error: unknown): boolean {
+    const statusCode = (error as { statusCode?: number } | null)?.statusCode
+    return statusCode === 404 || statusCode === 410
+  }
+}
+
+export default PushNotificationService
+export type { PushPayload }

--- a/src/notification/application/usecases/subscribe-push.usecase.ts
+++ b/src/notification/application/usecases/subscribe-push.usecase.ts
@@ -1,0 +1,33 @@
+import type { Roles } from '../../../auth/domain/entities/role'
+import PushSubscriptionEntity from '../../domain/entities/push-subscription.entity'
+import type SubscribePushPayload from '../../domain/payloads/subscribe-push.payload'
+import type PushSubscriptionRepository from '../../domain/repositories/push-subscription.repository'
+
+class SubscribePushUseCase {
+  constructor(private readonly repository: PushSubscriptionRepository) {}
+
+  async exec(recipientId: string, recipientRole: Roles, payload: SubscribePushPayload): Promise<void> {
+    // El mismo endpoint puede volver a suscribirse (re-login, refresh de permiso):
+    // upsert por endpoint en lugar de duplicar filas para el mismo dispositivo.
+    const existing = await this.repository.findByEndpoint(payload.endpoint)
+    if (existing != null) {
+      existing.recipientId = recipientId
+      existing.recipientRole = recipientRole
+      existing.p256dh = payload.keys.p256dh
+      existing.auth = payload.keys.auth
+      await this.repository.save(existing)
+      return
+    }
+
+    const subscription = new PushSubscriptionEntity(
+      recipientId,
+      recipientRole,
+      payload.endpoint,
+      payload.keys.p256dh,
+      payload.keys.auth
+    )
+    await this.repository.save(subscription)
+  }
+}
+
+export default SubscribePushUseCase

--- a/src/notification/application/usecases/unsubscribe-push.usecase.ts
+++ b/src/notification/application/usecases/unsubscribe-push.usecase.ts
@@ -1,0 +1,11 @@
+import type PushSubscriptionRepository from '../../domain/repositories/push-subscription.repository'
+
+class UnsubscribePushUseCase {
+  constructor(private readonly repository: PushSubscriptionRepository) {}
+
+  async exec(endpoint: string): Promise<void> {
+    await this.repository.deleteByEndpoint(endpoint)
+  }
+}
+
+export default UnsubscribePushUseCase

--- a/src/notification/domain/entities/push-subscription.entity.ts
+++ b/src/notification/domain/entities/push-subscription.entity.ts
@@ -1,0 +1,38 @@
+/* eslint-disable indent */
+import { Entity, Enum, Property, Unique } from '@mikro-orm/postgresql'
+import { Roles } from '../../../auth/domain/entities/role'
+import BaseEntity from '../../../shared/domain/entities/base.entity'
+
+// Una fila por dispositivo/navegador suscripto (no por usuario): el mismo
+// recipient puede tener varias suscripciones activas (celular + desktop).
+// `endpoint` es unico porque el navegador lo genera de forma estable por
+// instalacion -- reintentar el mismo dispositivo hace upsert, no duplica.
+@Entity({ tableName: 'push_subscriptions' })
+@Unique({ properties: ['endpoint'] })
+class PushSubscriptionEntity extends BaseEntity {
+  @Property()
+  recipientId: string
+
+  @Enum({ items: () => Roles })
+  recipientRole: Roles
+
+  @Property({ type: 'text' })
+  endpoint: string
+
+  @Property()
+  p256dh: string
+
+  @Property()
+  auth: string
+
+  constructor(recipientId: string, recipientRole: Roles, endpoint: string, p256dh: string, auth: string) {
+    super()
+    this.recipientId = recipientId
+    this.recipientRole = recipientRole
+    this.endpoint = endpoint
+    this.p256dh = p256dh
+    this.auth = auth
+  }
+}
+
+export default PushSubscriptionEntity

--- a/src/notification/domain/payloads/subscribe-push.payload.ts
+++ b/src/notification/domain/payloads/subscribe-push.payload.ts
@@ -1,0 +1,9 @@
+interface SubscribePushPayload {
+  endpoint: string
+  keys: {
+    p256dh: string
+    auth: string
+  }
+}
+
+export default SubscribePushPayload

--- a/src/notification/domain/repositories/push-subscription.repository.ts
+++ b/src/notification/domain/repositories/push-subscription.repository.ts
@@ -1,0 +1,12 @@
+import type { Roles } from '../../../auth/domain/entities/role'
+import type Nullable from '../../../shared/domain/types/nullable.type'
+import type PushSubscriptionEntity from '../entities/push-subscription.entity'
+
+interface PushSubscriptionRepository {
+  save: (subscription: PushSubscriptionEntity) => Promise<Nullable<PushSubscriptionEntity>>
+  findByEndpoint: (endpoint: string) => Promise<Nullable<PushSubscriptionEntity>>
+  findByRecipient: (recipientId: string, recipientRole: Roles) => Promise<PushSubscriptionEntity[]>
+  deleteByEndpoint: (endpoint: string) => Promise<void>
+}
+
+export default PushSubscriptionRepository

--- a/src/notification/domain/services/realtime-broadcaster.ts
+++ b/src/notification/domain/services/realtime-broadcaster.ts
@@ -1,0 +1,16 @@
+import type { Roles } from '../../../auth/domain/entities/role'
+import type { NotificationCategory } from '../enums/notification-category.enum'
+
+interface RealtimeEvent {
+  category: NotificationCategory
+  title: string
+  body: string
+  data?: Record<string, unknown>
+}
+
+interface RealtimeBroadcaster {
+  send: (recipientId: string, recipientRole: Roles, event: RealtimeEvent) => void
+}
+
+export default RealtimeBroadcaster
+export type { RealtimeEvent }

--- a/src/notification/infrastructure/dtos/subscribe-push.dto.ts
+++ b/src/notification/infrastructure/dtos/subscribe-push.dto.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+const SubscribePushDTO = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1)
+  })
+})
+
+export default SubscribePushDTO

--- a/src/notification/infrastructure/dtos/unsubscribe-push.dto.ts
+++ b/src/notification/infrastructure/dtos/unsubscribe-push.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+const UnsubscribePushDTO = z.object({
+  endpoint: z.string().url()
+})
+
+export default UnsubscribePushDTO

--- a/src/notification/infrastructure/handlers/notification.handler.ts
+++ b/src/notification/infrastructure/handlers/notification.handler.ts
@@ -1,15 +1,22 @@
 import { type FastifyReply, type FastifyRequest } from 'fastify'
 import HandleHTTPResponse from '../../../shared/utils/http.reply.util'
 import { getURLParams } from '../../../shared/utils/http.request.util'
+import EnvVar from '../../../shared/config/env-var.config'
 import type ListNotificationsByRecipientUseCase from '../../application/usecases/list-by-recipient.usecase'
 import type CountUnreadNotificationsUseCase from '../../application/usecases/count-unread.usecase'
 import type MarkNotificationAsReadUseCase from '../../application/usecases/mark-as-read.usecase'
 import type MarkAllNotificationsAsReadUseCase from '../../application/usecases/mark-all-as-read.usecase'
 import type FindOrCreateNotificationPreferenceUseCase from '../../application/usecases/find-or-create-preference.usecase'
 import type UpdateNotificationPreferenceUseCase from '../../application/usecases/update-preference.usecase'
+import type SubscribePushUseCase from '../../application/usecases/subscribe-push.usecase'
+import type UnsubscribePushUseCase from '../../application/usecases/unsubscribe-push.usecase'
 import NotificationSchemaValidator from '../middlewares/notification-schema-validator.middleware'
 import UpdateNotificationPreferenceDTO from '../dtos/update-preference.dto'
+import SubscribePushDTO from '../dtos/subscribe-push.dto'
+import UnsubscribePushDTO from '../dtos/unsubscribe-push.dto'
 import type NotificationPreferencePatch from '../../domain/payloads/notification-preference.payload'
+import type SubscribePushPayload from '../../domain/payloads/subscribe-push.payload'
+import type { SseConnectionRegistry } from '../realtime/sse-connection-registry'
 
 class NotificationHandler {
   constructor(
@@ -18,7 +25,10 @@ class NotificationHandler {
     private readonly markAsRead: MarkNotificationAsReadUseCase,
     private readonly markAllAsRead: MarkAllNotificationsAsReadUseCase,
     private readonly findOrCreatePreference: FindOrCreateNotificationPreferenceUseCase,
-    private readonly updatePreference: UpdateNotificationPreferenceUseCase
+    private readonly updatePreference: UpdateNotificationPreferenceUseCase,
+    private readonly subscribePush: SubscribePushUseCase,
+    private readonly unsubscribePush: UnsubscribePushUseCase,
+    private readonly realtimeRegistry: SseConnectionRegistry
   ) {}
 
   async list(req: FastifyRequest<{ Querystring: Record<string, string> }>, rep: FastifyReply): Promise<void> {
@@ -70,6 +80,55 @@ class NotificationHandler {
     const preference = await this.updatePreference.exec(req.user.sub, req.user.role, patch)
 
     HandleHTTPResponse.OK(rep, 'Notification preference updated successfully', preference)
+  }
+
+  getPushPublicKey(_req: FastifyRequest, rep: FastifyReply): void {
+    HandleHTTPResponse.OK(rep, 'Push public key retrieved successfully', { publicKey: EnvVar.push.publicKey })
+  }
+
+  async subscribePushHandler(req: FastifyRequest<{ Body: SubscribePushPayload }>, rep: FastifyReply): Promise<void> {
+    const validator = new NotificationSchemaValidator(SubscribePushDTO, req.body)
+    const payload = validator.exec()
+
+    await this.subscribePush.exec(req.user.sub, req.user.role, payload)
+
+    HandleHTTPResponse.OK(rep, 'Push subscription registered successfully')
+  }
+
+  async unsubscribePushHandler(req: FastifyRequest<{ Body: { endpoint: string } }>, rep: FastifyReply): Promise<void> {
+    const validator = new NotificationSchemaValidator(UnsubscribePushDTO, req.body)
+    const { endpoint } = validator.exec()
+
+    await this.unsubscribePush.exec(endpoint)
+
+    HandleHTTPResponse.OK(rep, 'Push subscription removed successfully')
+  }
+
+  // Conexion SSE de larga duracion: hijack() le saca a Fastify el control de
+  // la respuesta (si no, intenta serializarla/cerrarla como una request normal
+  // apenas este metodo retorna). El stream queda abierto hasta que el cliente
+  // cierra la conexion (`req.raw` emite 'close').
+  streamHandler(req: FastifyRequest, rep: FastifyReply): void {
+    rep.hijack()
+    rep.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive'
+    })
+    rep.raw.write(': connected\n\n')
+
+    this.realtimeRegistry.subscribe(req.user.sub, req.user.role, rep)
+
+    // Sin heartbeat, proxies/balanceadores intermedios cortan la conexion por
+    // inactividad mucho antes de que haya un evento real que emitir.
+    const heartbeat = setInterval(() => {
+      rep.raw.write(': heartbeat\n\n')
+    }, 25000)
+
+    req.raw.on('close', () => {
+      clearInterval(heartbeat)
+      this.realtimeRegistry.unsubscribe(req.user.sub, req.user.role, rep)
+    })
   }
 }
 

--- a/src/notification/infrastructure/middlewares/notification-schema-validator.middleware.ts
+++ b/src/notification/infrastructure/middlewares/notification-schema-validator.middleware.ts
@@ -1,12 +1,11 @@
 import { ZodError, type ZodType } from 'zod'
 import ErrorSchemaValidation from '../../../shared/domain/errors/schema-validation.error'
 import { formatZodErrorsToObject, formatZodErrorsToString } from '../../../shared/utils/hanlde-zod-error.util'
-import type NotificationPreferencePatch from '../../domain/payloads/notification-preference.payload'
 
 class NotificationSchemaValidator<TDTOSchema> {
   constructor(
     private readonly schema: ZodType<TDTOSchema>,
-    private readonly payload: NotificationPreferencePatch
+    private readonly payload: unknown
   ) {}
 
   exec(): TDTOSchema {

--- a/src/notification/infrastructure/realtime/sse-connection-registry.ts
+++ b/src/notification/infrastructure/realtime/sse-connection-registry.ts
@@ -1,0 +1,52 @@
+import type { FastifyReply } from 'fastify'
+import type { Roles } from '../../../auth/domain/entities/role'
+import type RealtimeBroadcaster from '../../domain/services/realtime-broadcaster'
+import type { RealtimeEvent } from '../../domain/services/realtime-broadcaster'
+
+// Singleton de modulo (una sola instancia para todo el proceso): tanto la
+// ruta /stream (que registra conexiones abiertas) como el NotificationDispatcher
+// (que las usa para emitir) necesitan ver el MISMO mapa de conexiones, aunque
+// cada bootstrap construya su propio dispatcher por request. Por eso esta
+// clase se exporta ya instanciada, no como algo para instanciar de nuevo.
+class SseConnectionRegistry implements RealtimeBroadcaster {
+  private readonly connections = new Map<string, Set<FastifyReply>>()
+
+  subscribe(recipientId: string, recipientRole: Roles, reply: FastifyReply): void {
+    const key = this.keyFor(recipientId, recipientRole)
+    const existing = this.connections.get(key)
+    if (existing != null) {
+      existing.add(reply)
+      return
+    }
+    this.connections.set(key, new Set([reply]))
+  }
+
+  unsubscribe(recipientId: string, recipientRole: Roles, reply: FastifyReply): void {
+    const key = this.keyFor(recipientId, recipientRole)
+    const existing = this.connections.get(key)
+    if (existing == null) return
+
+    existing.delete(reply)
+    if (existing.size === 0) this.connections.delete(key)
+  }
+
+  send(recipientId: string, recipientRole: Roles, event: RealtimeEvent): void {
+    const key = this.keyFor(recipientId, recipientRole)
+    const replies = this.connections.get(key)
+    if (replies == null || replies.size === 0) return
+
+    const payload = `data: ${JSON.stringify(event)}\n\n`
+    for (const reply of replies) {
+      reply.raw.write(payload)
+    }
+  }
+
+  private keyFor(recipientId: string, recipientRole: Roles): string {
+    return `${recipientRole}:${recipientId}`
+  }
+}
+
+const sseConnectionRegistry = new SseConnectionRegistry()
+
+export default sseConnectionRegistry
+export { SseConnectionRegistry }

--- a/src/notification/infrastructure/repositories/mikro-orm/push-subscription.mikroorm.repository.ts
+++ b/src/notification/infrastructure/repositories/mikro-orm/push-subscription.mikroorm.repository.ts
@@ -1,0 +1,41 @@
+import { RequestContext } from '@mikro-orm/core'
+import type { Roles } from '../../../../auth/domain/entities/role'
+import ErrorEntityManagerNotFound from '../../../../shared/domain/errors/entity-manager-not-found.error'
+import type Nullable from '../../../../shared/domain/types/nullable.type'
+import PushSubscriptionEntity from '../../../domain/entities/push-subscription.entity'
+import type PushSubscriptionRepository from '../../../domain/repositories/push-subscription.repository'
+
+class PushSubscriptionMikroORMRepository implements PushSubscriptionRepository {
+  async save(subscription: PushSubscriptionEntity): Promise<Nullable<PushSubscriptionEntity>> {
+    const em = this.getEntityManager()
+    await em.persist(subscription).flush()
+    return subscription
+  }
+
+  async findByEndpoint(endpoint: string): Promise<Nullable<PushSubscriptionEntity>> {
+    const em = this.getEntityManager()
+    return await em.findOne(PushSubscriptionEntity, { endpoint })
+  }
+
+  async findByRecipient(recipientId: string, recipientRole: Roles): Promise<PushSubscriptionEntity[]> {
+    const em = this.getEntityManager()
+    return await em.find(PushSubscriptionEntity, { recipientId, recipientRole })
+  }
+
+  async deleteByEndpoint(endpoint: string): Promise<void> {
+    const em = this.getEntityManager()
+    await em.nativeDelete(PushSubscriptionEntity, { endpoint })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  private getEntityManager() {
+    const em = RequestContext.getEntityManager()
+    if (em == null) {
+      throw new ErrorEntityManagerNotFound()
+    }
+
+    return em
+  }
+}
+
+export default PushSubscriptionMikroORMRepository

--- a/src/notification/infrastructure/routes/notification.route.ts
+++ b/src/notification/infrastructure/routes/notification.route.ts
@@ -2,6 +2,7 @@ import { type FastifyInstance, type FastifyRequest } from 'fastify'
 import { Roles } from '../../../auth/domain/entities/role'
 import type NotificationHandler from '../handlers/notification.handler'
 import type NotificationPreferencePatch from '../../domain/payloads/notification-preference.payload'
+import type SubscribePushPayload from '../../domain/payloads/subscribe-push.payload'
 
 // Solo estos 3 roles reciben notificaciones en este alcance (ver plan): un
 // vecino compra/canjea cupones y recibe entregas, un local crea cupones, un
@@ -49,6 +50,30 @@ class NotificationRoute {
       preHandler: this.server.protect(...NOTIFIABLE_ROLES),
       handler: async (req: FastifyRequest<{ Body: NotificationPreferencePatch }>, rep) => {
         await this.handler.updatePreferenceHandler(req, rep)
+      }
+    })
+    this.server.get('/api/notifications/push/public-key', {
+      preHandler: this.server.protect(...NOTIFIABLE_ROLES),
+      handler: (req, rep) => {
+        this.handler.getPushPublicKey(req, rep)
+      }
+    })
+    this.server.post('/api/notifications/push/subscribe', {
+      preHandler: this.server.protect(...NOTIFIABLE_ROLES),
+      handler: async (req: FastifyRequest<{ Body: SubscribePushPayload }>, rep) => {
+        await this.handler.subscribePushHandler(req, rep)
+      }
+    })
+    this.server.delete('/api/notifications/push/subscribe', {
+      preHandler: this.server.protect(...NOTIFIABLE_ROLES),
+      handler: async (req: FastifyRequest<{ Body: { endpoint: string } }>, rep) => {
+        await this.handler.unsubscribePushHandler(req, rep)
+      }
+    })
+    this.server.get('/api/notifications/stream', {
+      preHandler: this.server.protect(...NOTIFIABLE_ROLES),
+      handler: (req, rep) => {
+        this.handler.streamHandler(req, rep)
       }
     })
   }

--- a/src/notification/notification-dispatcher.factory.ts
+++ b/src/notification/notification-dispatcher.factory.ts
@@ -2,8 +2,11 @@ import EmailService from '../auth/application/service/email.service'
 import FindOrCreateNotificationPreferenceUseCase from './application/usecases/find-or-create-preference.usecase'
 import RegisterNotificationUseCase from './application/usecases/register.usecase'
 import NotificationDispatcher from './application/service/notification-dispatcher.service'
+import PushNotificationService from './application/service/push-notification.service'
 import NotificationMikroORMRepository from './infrastructure/repositories/mikro-orm/notification.mikroorm.repository'
 import NotificationPreferenceMikroORMRepository from './infrastructure/repositories/mikro-orm/notification-preference.mikroorm.repository'
+import PushSubscriptionMikroORMRepository from './infrastructure/repositories/mikro-orm/push-subscription.mikroorm.repository'
+import sseConnectionRegistry from './infrastructure/realtime/sse-connection-registry'
 
 // No hay contenedor de DI en el repo (todo el wiring es manual con `new` en
 // cada bootstrap). Esta fabrica evita repetir la misma cadena de construccion
@@ -12,12 +15,20 @@ import NotificationPreferenceMikroORMRepository from './infrastructure/repositor
 function createNotificationDispatcher(): NotificationDispatcher {
   const notificationRepository = new NotificationMikroORMRepository()
   const preferenceRepository = new NotificationPreferenceMikroORMRepository()
+  const pushSubscriptionRepository = new PushSubscriptionMikroORMRepository()
 
   const findOrCreatePreference = new FindOrCreateNotificationPreferenceUseCase(preferenceRepository)
   const registerNotification = new RegisterNotificationUseCase(notificationRepository)
   const emailService = new EmailService()
+  const pushService = new PushNotificationService(pushSubscriptionRepository)
 
-  return new NotificationDispatcher(findOrCreatePreference, registerNotification, emailService)
+  return new NotificationDispatcher(
+    findOrCreatePreference,
+    registerNotification,
+    emailService,
+    pushService,
+    sseConnectionRegistry
+  )
 }
 
 export default createNotificationDispatcher

--- a/src/notification/notification.bootstrap.ts
+++ b/src/notification/notification.bootstrap.ts
@@ -1,20 +1,26 @@
 import { type FastifyInstance } from 'fastify'
 import type NotificationRepository from './domain/repositories/notification.repository'
 import type NotificationPreferenceRepository from './domain/repositories/notification-preference.repository'
+import type PushSubscriptionRepository from './domain/repositories/push-subscription.repository'
 import NotificationMikroORMRepository from './infrastructure/repositories/mikro-orm/notification.mikroorm.repository'
 import NotificationPreferenceMikroORMRepository from './infrastructure/repositories/mikro-orm/notification-preference.mikroorm.repository'
+import PushSubscriptionMikroORMRepository from './infrastructure/repositories/mikro-orm/push-subscription.mikroorm.repository'
 import ListNotificationsByRecipientUseCase from './application/usecases/list-by-recipient.usecase'
 import CountUnreadNotificationsUseCase from './application/usecases/count-unread.usecase'
 import MarkNotificationAsReadUseCase from './application/usecases/mark-as-read.usecase'
 import MarkAllNotificationsAsReadUseCase from './application/usecases/mark-all-as-read.usecase'
 import FindOrCreateNotificationPreferenceUseCase from './application/usecases/find-or-create-preference.usecase'
 import UpdateNotificationPreferenceUseCase from './application/usecases/update-preference.usecase'
+import SubscribePushUseCase from './application/usecases/subscribe-push.usecase'
+import UnsubscribePushUseCase from './application/usecases/unsubscribe-push.usecase'
 import NotificationHandler from './infrastructure/handlers/notification.handler'
 import NotificationRoute from './infrastructure/routes/notification.route'
+import sseConnectionRegistry from './infrastructure/realtime/sse-connection-registry'
 
 async function bootstrapNotification(router: FastifyInstance): Promise<void> {
   const notificationRepository: NotificationRepository = new NotificationMikroORMRepository()
   const preferenceRepository: NotificationPreferenceRepository = new NotificationPreferenceMikroORMRepository()
+  const pushSubscriptionRepository: PushSubscriptionRepository = new PushSubscriptionMikroORMRepository()
 
   const listNotifications = new ListNotificationsByRecipientUseCase(notificationRepository)
   const countUnread = new CountUnreadNotificationsUseCase(notificationRepository)
@@ -22,6 +28,8 @@ async function bootstrapNotification(router: FastifyInstance): Promise<void> {
   const markAllAsRead = new MarkAllNotificationsAsReadUseCase(notificationRepository)
   const findOrCreatePreference = new FindOrCreateNotificationPreferenceUseCase(preferenceRepository)
   const updatePreference = new UpdateNotificationPreferenceUseCase(findOrCreatePreference, preferenceRepository)
+  const subscribePush = new SubscribePushUseCase(pushSubscriptionRepository)
+  const unsubscribePush = new UnsubscribePushUseCase(pushSubscriptionRepository)
 
   const handler = new NotificationHandler(
     listNotifications,
@@ -29,7 +37,10 @@ async function bootstrapNotification(router: FastifyInstance): Promise<void> {
     markAsRead,
     markAllAsRead,
     findOrCreatePreference,
-    updatePreference
+    updatePreference,
+    subscribePush,
+    unsubscribePush,
+    sseConnectionRegistry
   )
 
   const routes = new NotificationRoute(router, handler)

--- a/src/notification/test/notification-dispatcher.unit.test.ts
+++ b/src/notification/test/notification-dispatcher.unit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import type EmailService from '../../auth/application/service/email.service'
 import { Roles } from '../../auth/domain/entities/role'
 import NotificationDispatcher from '../application/service/notification-dispatcher.service'
+import type PushNotificationService from '../application/service/push-notification.service'
+import type RealtimeBroadcaster from '../domain/services/realtime-broadcaster'
 import type FindOrCreateNotificationPreferenceUseCase from '../application/usecases/find-or-create-preference.usecase'
 import type RegisterNotificationUseCase from '../application/usecases/register.usecase'
 import { NotificationCategory } from '../domain/enums/notification-category.enum'
@@ -14,7 +16,9 @@ function makeDispatcher(
   return new NotificationDispatcher(
     findOrCreatePreference as FindOrCreateNotificationPreferenceUseCase,
     registerNotification as RegisterNotificationUseCase,
-    {} as unknown as EmailService
+    {} as unknown as EmailService,
+    { sendToRecipient: vi.fn() } as unknown as PushNotificationService,
+    { send: vi.fn() } as unknown as RealtimeBroadcaster
   )
 }
 

--- a/src/notification/test/push-notification.service.unit.test.ts
+++ b/src/notification/test/push-notification.service.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import webpushImport from 'web-push'
+import { Roles } from '../../auth/domain/entities/role'
+import PushSubscriptionEntity from '../domain/entities/push-subscription.entity'
+import type PushSubscriptionRepository from '../domain/repositories/push-subscription.repository'
+import PushNotificationService from '../application/service/push-notification.service'
+
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn()
+  }
+}))
+
+const webpush = webpushImport as unknown as {
+  setVapidDetails: ReturnType<typeof vi.fn>
+  sendNotification: ReturnType<typeof vi.fn>
+}
+
+function makeSubscription(endpoint: string): PushSubscriptionEntity {
+  return new PushSubscriptionEntity('neighbor-1', Roles.NEIGHBOR, endpoint, 'p256dh-key', 'auth-key')
+}
+
+describe('PushNotificationService — unit tests', () => {
+  it('envía el push a todas las suscripciones del destinatario', async () => {
+    const subscriptions = [makeSubscription('https://push.example/a'), makeSubscription('https://push.example/b')]
+    const repository: Partial<PushSubscriptionRepository> = {
+      findByRecipient: async () => subscriptions,
+      deleteByEndpoint: vi.fn()
+    }
+    webpush.sendNotification.mockResolvedValue(undefined)
+
+    const service = new PushNotificationService(repository as PushSubscriptionRepository)
+    await service.sendToRecipient('neighbor-1', Roles.NEIGHBOR, { title: 'Título', body: 'Cuerpo' })
+
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(2)
+    expect(repository.deleteByEndpoint).not.toHaveBeenCalled()
+  })
+
+  it('borra la suscripción cuando el navegador la invalidó (410)', async () => {
+    const subscription = makeSubscription('https://push.example/gone')
+    const deleteByEndpoint = vi.fn()
+    const repository: Partial<PushSubscriptionRepository> = {
+      findByRecipient: async () => [subscription],
+      deleteByEndpoint
+    }
+    webpush.sendNotification.mockRejectedValueOnce({ statusCode: 410 })
+
+    const service = new PushNotificationService(repository as PushSubscriptionRepository)
+    await expect(
+      service.sendToRecipient('neighbor-1', Roles.NEIGHBOR, { title: 'Título', body: 'Cuerpo' })
+    ).resolves.toBeUndefined()
+
+    expect(deleteByEndpoint).toHaveBeenCalledWith('https://push.example/gone')
+  })
+
+  it('no rompe ni borra la suscripción ante otros errores de envío', async () => {
+    const subscription = makeSubscription('https://push.example/error')
+    const deleteByEndpoint = vi.fn()
+    const repository: Partial<PushSubscriptionRepository> = {
+      findByRecipient: async () => [subscription],
+      deleteByEndpoint
+    }
+    webpush.sendNotification.mockRejectedValueOnce({ statusCode: 500 })
+
+    const service = new PushNotificationService(repository as PushSubscriptionRepository)
+    await expect(
+      service.sendToRecipient('neighbor-1', Roles.NEIGHBOR, { title: 'Título', body: 'Cuerpo' })
+    ).resolves.toBeUndefined()
+
+    expect(deleteByEndpoint).not.toHaveBeenCalled()
+  })
+})

--- a/src/reward-partner/infrastructure/routes/reward-partner.route.ts
+++ b/src/reward-partner/infrastructure/routes/reward-partner.route.ts
@@ -30,7 +30,7 @@ class RewardPartnerRoute {
       }
     })
     this.server.get('/api/reward-partner', {
-      preHandler: this.server.protect(Roles.ENTITY, Roles.RESPONSIBLE, Roles.REWARD_PARTNER),
+      preHandler: this.server.protect(Roles.ENTITY, Roles.RESPONSIBLE, Roles.REWARD_PARTNER, Roles.NEIGHBOR),
       handler: async (req: FastifyRequest<{ Querystring: Record<string, string> }>, rep) => {
         await this.handler.list(req, rep)
       }

--- a/src/shared/config/env-var.config.js
+++ b/src/shared/config/env-var.config.js
@@ -38,6 +38,11 @@ const emailConfig = {
     user: env_var_1.default.get('EMAIL_USER').required().asString(),
     appPassword: env_var_1.default.get('EMAIL_APP_PASSWORD').required().asString()
 };
+const pushConfig = {
+    publicKey: env_var_1.default.get('VAPID_PUBLIC_KEY').required().asString(),
+    privateKey: env_var_1.default.get('VAPID_PRIVATE_KEY').required().asString(),
+    contactEmail: env_var_1.default.get('VAPID_CONTACT_EMAIL').default(emailConfig.user).asString()
+};
 // In production, CORS origins MUST be provided explicitly (no wildcard, no localhost defaults):
 // env-var only throws on a missing required var when no default is set, so production omits the default.
 // In development/test we fall back to localhost so the local frontend works out of the box.
@@ -59,6 +64,7 @@ const EnvVar = {
     testDatabase: testDatabaseConfig,
     recaptcha: recaptchaConfig,
     email: emailConfig,
+    push: pushConfig,
     cors: corsConfig,
     admin: adminConfig
 };

--- a/src/shared/config/env-var.config.ts
+++ b/src/shared/config/env-var.config.ts
@@ -33,6 +33,12 @@ interface EmailConfig {
   appPassword: string
 }
 
+interface PushConfig {
+  publicKey: string
+  privateKey: string
+  contactEmail: string
+}
+
 interface CorsConfig {
   allowedOrigins: string[]
 }
@@ -60,6 +66,7 @@ interface Config {
   testDatabase: DatabaseConfig
   recaptcha: Recaptcha
   email: EmailConfig
+  push: PushConfig
   cors: CorsConfig
   admin: AdminConfig
   prodEntity: ProdEntityConfig
@@ -115,6 +122,12 @@ const emailConfig: EmailConfig = {
   appPassword: env.get('EMAIL_APP_PASSWORD').required().asString()
 }
 
+const pushConfig: PushConfig = {
+  publicKey: env.get('VAPID_PUBLIC_KEY').required().asString(),
+  privateKey: env.get('VAPID_PRIVATE_KEY').required().asString(),
+  contactEmail: env.get('VAPID_CONTACT_EMAIL').default(emailConfig.user).asString()
+}
+
 // In production, CORS origins MUST be provided explicitly (no wildcard, no localhost defaults):
 // env-var only throws on a missing required var when no default is set, so production omits the default.
 // In development/test we fall back to localhost so the local frontend works out of the box.
@@ -153,6 +166,7 @@ const EnvVar: Config = {
   testDatabase: testDatabaseConfig,
   recaptcha: recaptchaConfig,
   email: emailConfig,
+  push: pushConfig,
   cors: corsConfig,
   admin: adminConfig,
   prodEntity: prodEntityConfig

--- a/src/waste-transaction/application/usecases/register-waste-delivery.usecase.ts
+++ b/src/waste-transaction/application/usecases/register-waste-delivery.usecase.ts
@@ -58,6 +58,10 @@ class RegisterWasteDeliveryUseCase {
       category: NotificationCategory.POINTS_DELIVERED,
       title: 'Entrega registrada',
       body: `Se registró tu entrega y sumaste ${transaction.totalPoints} puntos.`,
+      // totalPoints es el saldo del vecino YA con esta entrega sumada (addPoints
+      // corrió arriba, en el loop): el front lo usa como valor final para animar
+      // el contador desde el saldo anterior hasta este.
+      data: { points: transaction.totalPoints, totalPoints: neighbor.points },
       sendEmail: async emailService => {
         await emailService.sendWasteDeliveryConfirmation(
           neighbor.email,


### PR DESCRIPTION
…en tiempo real

Suma un canal de Web Push (VAPID + web-push) y un canal SSE al NotificationDispatcher existente, junto a los canales de in-app y mail ya presentes.

- Nuevas entidades/usecases/rutas para suscripcion push del navegador
- SseConnectionRegistry (singleton) + GET /api/notifications/stream para que el front reciba eventos en vivo sin refrescar
- COUPON_CREATED ahora tambien notifica a los vecinos de la entidad (antes solo al local) para que vean el cupon nuevo en el catalogo
- COUPON_PURCHASED ahora tambien notifica al local dueno del cupon