### PR TITLE
fix(ci): usar claves VAPID genericas y corregir esquema de gitguardian

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -3,12 +3,26 @@
 #
 # Ignora archivos que contienen placeholders intencionales o config de CI,
 # para evitar falsos positivos en cada push.
+#
+# OJO: en version 2 los ignores van anidados bajo `secret:` (ignored_paths /
+# ignored_matches), no como claves de primer nivel — un `paths-ignore` suelto
+# no lo reconoce ggshield y queda sin efecto.
 version: 2
 
-paths-ignore:
-  # Template de variables de entorno — los valores son placeholders
-  - '.env.example'
-  - '**/.env.example'
+secret:
+  ignored_paths:
+    # Template de variables de entorno — los valores son placeholders
+    - '.env.example'
+    - '**/.env.example'
 
-  # CI workflow — usa valores de prueba no-sensibles
-  - '.github/workflows/ci.yml'
+    # CI workflow — usa valores de prueba no-sensibles
+    - '.github/workflows/ci.yml'
+
+  ignored_matches:
+    # Claves VAPID dummy (65/32 bytes en cero) usadas solo para que el job
+    # de test pueda instanciar el servicio de push notifications — no son
+    # credenciales reales.
+    - name: ci-vapid-test-keys
+      match: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    - name: ci-vapid-test-keys-private
+      match: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           ADMIN_EMAIL: admin@example.com
           ADMIN_PASSWORD: test_password
           CORS_ALLOWED_ORIGINS: localhost
-          VAPID_PUBLIC_KEY: BPyuXIbz0QLLjqa5GK1HRVqMoEU7y3VFV6JPC27UMtsnUJpDr6Wdpa5M0TqBQp2hfgo0xAJqrq2EAoX33iND-Yw
-          VAPID_PRIVATE_KEY: n5hwwYRl4VU-ixEiLZlkITQ1QP3VvhzaHCQVtJ366VY
+          # Claves dummy (65/32 bytes en cero, formato base64url) — pasan la
+          # validacion de longitud de web-push pero no son secretos reales.
+          VAPID_PUBLIC_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          VAPID_PRIVATE_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         run: pnpm run test


### PR DESCRIPTION
- Las VAPID keys del job de test eran un keypair real generado ad-hoc; se reemplazan por bytes en cero (65/32 bytes validos en formato para web-push, pero sin entropia real).
- .gitguardian.yml declaraba version: 2 pero usaba paths-ignore como clave de primer nivel; en esa version ggshield espera todo anidado bajo secret.ignored_paths/secret.ignored_matches, asi que la excepcion de ci.yml nunca estuvo activa. Se corrige el esquema y se suma un ignored_matches explicito para las VAPID keys dummy.