### PR TITLE
fix(notification): incluir headers CORS en la respuesta hijackeada de…

### DIFF
--- a/src/notification/infrastructure/handlers/notification.handler.ts
+++ b/src/notification/infrastructure/handlers/notification.handler.ts
@@ -109,8 +109,18 @@ class NotificationHandler {
   // apenas este metodo retorna). El stream queda abierto hasta que el cliente
   // cierra la conexion (`req.raw` emite 'close').
   streamHandler(req: FastifyRequest, rep: FastifyReply): void {
+    // @fastify/cors ya cargo estos headers via reply.header() en su hook
+    // onRequest, pero hijack() + writeHead() manual pisan por completo el
+    // envio normal de Fastify y se pierden si no se copian aca.
+    const corsHeaders: Record<string, string> = {}
+    const allowOrigin = rep.getHeader('access-control-allow-origin')
+    if (typeof allowOrigin === 'string') corsHeaders['Access-Control-Allow-Origin'] = allowOrigin
+    const allowCredentials = rep.getHeader('access-control-allow-credentials')
+    if (typeof allowCredentials === 'string') corsHeaders['Access-Control-Allow-Credentials'] = allowCredentials
+
     rep.hijack()
     rep.raw.writeHead(200, {
+      ...corsHeaders,
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache, no-transform',
       Connection: 'keep-alive'


### PR DESCRIPTION
…l stream SSE

reply.hijack() + rep.raw.writeHead() manual pisaban el envio normal de Fastify, perdiendo los headers Access-Control-Allow-Origin/-Credentials que @fastify/cors ya habia cargado via reply.header() en su hook onRequest. El navegador recibia 200 pero bloqueaba la lectura por CORS, y el cliente reintentaba la conexion cada 5s indefinidamente.