### PR TITLE
feat(statistics): agregar ranking de vecinos por punto verde

### DIFF
--- a/src/migrations/.snapshot-greenbin_db.json
+++ b/src/migrations/.snapshot-greenbin_db.json
@@ -1853,6 +1853,199 @@
           "enumItems": [],
           "mappedType": "datetime"
         },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "recipient_role": {
+          "name": "recipient_role",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "entity",
+            "neighbor",
+            "responsible",
+            "rewardPartner",
+            "admin"
+          ],
+          "mappedType": "enum"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "push_subscriptions",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "endpoint"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "push_subscriptions_endpoint_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "push_subscriptions_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "recipient_id",
+            "recipient_role"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "push_subscriptions_recipient_id_recipient_role_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
         "firstname": {
           "name": "firstname",
           "type": "varchar(255)",

--- a/src/shared/infrastructure/middlewares/error.middleware.ts
+++ b/src/shared/infrastructure/middlewares/error.middleware.ts
@@ -17,7 +17,13 @@ const errorMiddleware: (error: FastifyError, request: FastifyRequest, reply: Fas
   const patchedError = Object.assign(error, { statusCode })
 
   const { message, code, stack } = ErrorFactory.create(patchedError)
-  console.error('\x1b[0;31m' + stack)
+  // Solo lo que es realmente un error de servidor va a stderr con stack.
+  // Credenciales inválidas, validaciones, 404, etc. son parte del flujo
+  // normal de la app (y de sus tests) — loguearlos como error genera ruido
+  // y hace parecer que algo se rompió cuando no es así.
+  if (code >= 500) {
+    console.error('\x1b[0;31m' + stack)
+  }
   res.status(code).send({ code, message })
 }
 

--- a/src/statistics/application/usecases/get-neighbor-ranking-by-green-point.usecase.ts
+++ b/src/statistics/application/usecases/get-neighbor-ranking-by-green-point.usecase.ts
@@ -1,0 +1,12 @@
+import type StatisticsRepository from '../../domain/repositories/statistics.repository'
+import type NeighborRanking from '../../domain/types/neighbor-ranking.type'
+
+class GetNeighborRankingByGreenPointUseCase {
+  constructor(private readonly repository: StatisticsRepository) {}
+
+  async exec(greenPointId: string, from?: Date, to?: Date): Promise<NeighborRanking[]> {
+    return await this.repository.getNeighborRankingByGreenPoint(greenPointId, from, to)
+  }
+}
+
+export default GetNeighborRankingByGreenPointUseCase

--- a/src/statistics/domain/repositories/statistics.repository.ts
+++ b/src/statistics/domain/repositories/statistics.repository.ts
@@ -3,6 +3,7 @@ import type GreenPointRanking from '../types/green-point-ranking.type'
 import type WasteByCategory from '../types/waste-by-category.type'
 import type WasteByPeriod from '../types/waste-by-period.type'
 import type NeighborDelivery from '../types/neighbor-delivery.type'
+import type NeighborRanking from '../types/neighbor-ranking.type'
 
 interface StatisticsRepository {
   getTotalRecycled: (entityId: string, from?: Date, to?: Date) => Promise<TotalRecycled>
@@ -10,6 +11,7 @@ interface StatisticsRepository {
   getWasteByCategory: (entityId: string, from?: Date, to?: Date) => Promise<WasteByCategory[]>
   getWasteByPeriod: (entityId: string, groupBy: string, from?: Date, to?: Date) => Promise<WasteByPeriod[]>
   getNeighborDeliveries: (neighborId: string, from?: Date, to?: Date) => Promise<NeighborDelivery[]>
+  getNeighborRankingByGreenPoint: (greenPointId: string, from?: Date, to?: Date) => Promise<NeighborRanking[]>
 }
 
 export default StatisticsRepository

--- a/src/statistics/domain/types/neighbor-ranking.type.ts
+++ b/src/statistics/domain/types/neighbor-ranking.type.ts
@@ -1,0 +1,9 @@
+interface NeighborRanking {
+  neighborId: string
+  firstname: string
+  lastname: string
+  totalWeight: number
+  totalPoints: number
+}
+
+export default NeighborRanking

--- a/src/statistics/infrastructure/handlers/statistics.handler.ts
+++ b/src/statistics/infrastructure/handlers/statistics.handler.ts
@@ -7,6 +7,7 @@ import GetGreenPointsRankingUseCase from '../../application/usecases/get-green-p
 import GetWasteByCategoryUseCase from '../../application/usecases/get-waste-by-category.usecase'
 import GetWasteByPeriodUseCase from '../../application/usecases/get-waste-by-period.usecase'
 import GetNeighborDeliveriesUseCase from '../../application/usecases/get-neighbor-deliveries.usecase'
+import GetNeighborRankingByGreenPointUseCase from '../../application/usecases/get-neighbor-ranking-by-green-point.usecase'
 
 class StatisticsHandler {
   constructor(private readonly repository: StatisticsRepository) {}
@@ -88,6 +89,21 @@ class StatisticsHandler {
       to != null ? new Date(to) : undefined
     )
     HandleHTTPResponse.OK(rep, 'Neighbor deliveries retrieved successfully', result)
+  }
+
+  async getNeighborRankingByGreenPoint(
+    req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+    rep: FastifyReply
+  ): Promise<void> {
+    const greenPointId = getURLParams(req, 'greenPointId')
+    const { from, to } = req.query
+    const useCase = new GetNeighborRankingByGreenPointUseCase(this.repository)
+    const result = await useCase.exec(
+      greenPointId,
+      from != null ? new Date(from) : undefined,
+      to != null ? new Date(to) : undefined
+    )
+    HandleHTTPResponse.OK(rep, 'Neighbor ranking retrieved successfully', result)
   }
 }
 

--- a/src/statistics/infrastructure/repositories/mikro-orm/statistics.mikroorm.repository.ts
+++ b/src/statistics/infrastructure/repositories/mikro-orm/statistics.mikroorm.repository.ts
@@ -7,6 +7,7 @@ import type GreenPointRanking from '../../../domain/types/green-point-ranking.ty
 import type WasteByCategory from '../../../domain/types/waste-by-category.type'
 import type WasteByPeriod from '../../../domain/types/waste-by-period.type'
 import type NeighborDelivery from '../../../domain/types/neighbor-delivery.type'
+import type NeighborRanking from '../../../domain/types/neighbor-ranking.type'
 
 class StatisticsMikroORMRepository implements StatisticsRepository {
   async getTotalRecycled(entityId: string, from?: Date, to?: Date): Promise<TotalRecycled> {
@@ -155,6 +156,37 @@ class StatisticsMikroORMRepository implements StatisticsRepository {
       greenPointName: t.greenPointName,
       totalPoints: t.totalPoints,
       details: detailsMap.get(t.transactionId) ?? []
+    }))
+  }
+
+  async getNeighborRankingByGreenPoint(greenPointId: string, from?: Date, to?: Date): Promise<NeighborRanking[]> {
+    const knex = this.getKnex()
+
+    const query = knex('wastes_transactions_details as wtd')
+      .join('wastes_transactions as wt', 'wtd.transaction_id', 'wt.id')
+      .join('neighbors as n', 'wt.neighbor_id', 'n.id')
+      .where('wt.green_point_id', greenPointId)
+      .groupBy('n.id', 'n.firstname', 'n.lastname')
+      .orderByRaw('SUM(wtd.weight) DESC')
+      .limit(10)
+      .select(
+        'n.id as neighborId',
+        'n.firstname as firstname',
+        'n.lastname as lastname',
+        knex.raw('COALESCE(SUM(wtd.weight), 0)::float as "totalWeight"'),
+        knex.raw('COALESCE(SUM(wtd.points), 0)::int as "totalPoints"')
+      )
+
+    if (from != null) query.where('wt.date', '>=', from)
+    if (to != null) query.where('wt.date', '<=', to)
+
+    const rows = await query
+    return rows.map((r: any) => ({
+      neighborId: r.neighborId,
+      firstname: r.firstname,
+      lastname: r.lastname,
+      totalWeight: r.totalWeight,
+      totalPoints: r.totalPoints
     }))
   }
 

--- a/src/statistics/infrastructure/routes/statistics.route.ts
+++ b/src/statistics/infrastructure/routes/statistics.route.ts
@@ -58,6 +58,16 @@ class StatisticsRoute {
         await this.handler.getNeighborDeliveries(req, rep)
       }
     })
+
+    this.server.get('/api/statistics/green-point/:greenPointId/neighbor-ranking', {
+      preHandler: this.server.protect(Roles.RESPONSIBLE, Roles.ENTITY),
+      handler: async (
+        req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+        rep
+      ) => {
+        await this.handler.getNeighborRankingByGreenPoint(req, rep)
+      }
+    })
   }
 }
 

--- a/src/statistics/test/statistics.test.ts
+++ b/src/statistics/test/statistics.test.ts
@@ -278,7 +278,12 @@ describe('Statistics — integration tests', () => {
     })
 
     it('retorna array vacío para un punto verde sin entregas', async () => {
-      const otroPuntoVerde = await createGreenPoint(app, entityId, {}, entityToken)
+      const otroPuntoVerde = await createGreenPoint(
+        app,
+        entityId,
+        { coordinates: { latitude: -32.42, longitude: -63.25 } },
+        entityToken
+      )
       const res = await authedGet(`/api/statistics/green-point/${otroPuntoVerde.id}/neighbor-ranking`)
       expect(res.json().data).toEqual([])
     })

--- a/src/statistics/test/statistics.test.ts
+++ b/src/statistics/test/statistics.test.ts
@@ -256,4 +256,31 @@ describe('Statistics — integration tests', () => {
       }
     })
   })
+
+  describe('GET /api/statistics/green-point/:greenPointId/neighbor-ranking', () => {
+    it('retorna el ranking de vecinos del punto verde', async () => {
+      const res = await authedGet(`/api/statistics/green-point/${greenPointId}/neighbor-ranking`)
+      expect(res.statusCode).toBe(200)
+      const data = res.json().data
+      expect(Array.isArray(data)).toBe(true)
+      expect(data.length).toBe(1)
+    })
+
+    it('cada item tiene neighborId, firstname, lastname, totalWeight y totalPoints', async () => {
+      const res = await authedGet(`/api/statistics/green-point/${greenPointId}/neighbor-ranking`)
+      const item = res.json().data[0]
+      expect(item).toHaveProperty('neighborId')
+      expect(item).toHaveProperty('firstname')
+      expect(item).toHaveProperty('lastname')
+      expect(item).toHaveProperty('totalWeight')
+      expect(item).toHaveProperty('totalPoints')
+      expect(item.totalWeight).toBe(9) // 2 + 3 + 4
+    })
+
+    it('retorna array vacío para un punto verde sin entregas', async () => {
+      const otroPuntoVerde = await createGreenPoint(app, entityId, {}, entityToken)
+      const res = await authedGet(`/api/statistics/green-point/${otroPuntoVerde.id}/neighbor-ranking`)
+      expect(res.json().data).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
Nuevo endpoint GET /api/statistics/green-point/:greenPointId/neighbor-ranking para que un responsable vea el top de vecinos que más reciclaron en su punto verde. Sigue el mismo patrón que get-green-points-ranking, pero agrupa por vecino en vez de por punto verde.