### PR TITLE
perf(coupon-transaction): stats agregadas en SQL + paginación opcional

### DIFF
--- a/src/coupon-transaction/application/usecases/get-reward-partner-stats.usecase.ts
+++ b/src/coupon-transaction/application/usecases/get-reward-partner-stats.usecase.ts
@@ -1,0 +1,12 @@
+import type CouponTransactionRepository from '../../domain/repositories/coupon-transaction.repository'
+import type RewardPartnerStats from '../../domain/types/reward-partner-stats.type'
+
+class GetRewardPartnerStatsUseCase {
+  constructor(private readonly repository: CouponTransactionRepository) {}
+
+  async exec(rewardPartnerId: string, from?: Date, to?: Date): Promise<RewardPartnerStats> {
+    return await this.repository.getRewardPartnerStats(rewardPartnerId, from, to)
+  }
+}
+
+export default GetRewardPartnerStatsUseCase

--- a/src/coupon-transaction/application/usecases/list-by-neighbor.usecase.ts
+++ b/src/coupon-transaction/application/usecases/list-by-neighbor.usecase.ts
@@ -4,8 +4,8 @@ import type CouponTransactionEntity from '../../domain/entities/coupon-transacti
 class ListByNeighborUseCase {
   constructor(private readonly repository: CouponTransactionRepository) {}
 
-  async exec(neighborId: string): Promise<CouponTransactionEntity[]> {
-    const transactions = await this.repository.findByNeighbor(neighborId)
+  async exec(neighborId: string, offset?: number, limit?: number): Promise<CouponTransactionEntity[]> {
+    const transactions = await this.repository.findByNeighbor(neighborId, offset, limit)
     const now = new Date()
 
     for (const t of transactions) {

--- a/src/coupon-transaction/application/usecases/list-by-reward-partner.usecase.ts
+++ b/src/coupon-transaction/application/usecases/list-by-reward-partner.usecase.ts
@@ -4,8 +4,8 @@ import type CouponTransactionEntity from '../../domain/entities/coupon-transacti
 class ListByRewardPartnerUseCase {
   constructor(private readonly repository: CouponTransactionRepository) {}
 
-  async exec(rewardPartnerId: string): Promise<CouponTransactionEntity[]> {
-    return await this.repository.findByRewardPartner(rewardPartnerId)
+  async exec(rewardPartnerId: string, offset?: number, limit?: number): Promise<CouponTransactionEntity[]> {
+    return await this.repository.findByRewardPartner(rewardPartnerId, offset, limit)
   }
 }
 

--- a/src/coupon-transaction/domain/repositories/coupon-transaction.repository.ts
+++ b/src/coupon-transaction/domain/repositories/coupon-transaction.repository.ts
@@ -1,15 +1,17 @@
 import type Nullable from '../../../shared/domain/types/nullable.type'
 import type CouponTransactionEntity from '../entities/coupon-transaction.entity'
+import type RewardPartnerStats from '../types/reward-partner-stats.type'
 
 interface CouponTransactionRepository {
   list: (offset?: number, limit?: number) => Promise<Nullable<CouponTransactionEntity[]>>
   find: (property: Record<string, string>) => Promise<Nullable<CouponTransactionEntity>>
   findById: (id: string) => Promise<Nullable<CouponTransactionEntity>>
-  findByNeighbor: (neighborId: string) => Promise<CouponTransactionEntity[]>
-  findByRewardPartner: (rewardPartnerId: string) => Promise<CouponTransactionEntity[]>
+  findByNeighbor: (neighborId: string, offset?: number, limit?: number) => Promise<CouponTransactionEntity[]>
+  findByRewardPartner: (rewardPartnerId: string, offset?: number, limit?: number) => Promise<CouponTransactionEntity[]>
   findByCode: (code: string) => Promise<Nullable<CouponTransactionEntity>>
   save: (transaction: CouponTransactionEntity) => Promise<Nullable<CouponTransactionEntity>>
   update: (id: string, transaction: CouponTransactionEntity) => Promise<Nullable<CouponTransactionEntity>>
+  getRewardPartnerStats: (rewardPartnerId: string, from?: Date, to?: Date) => Promise<RewardPartnerStats>
 }
 
 export default CouponTransactionRepository

--- a/src/coupon-transaction/domain/types/reward-partner-stats.type.ts
+++ b/src/coupon-transaction/domain/types/reward-partner-stats.type.ts
@@ -1,0 +1,25 @@
+interface RewardPartnerStats {
+  totalAdquirido: number
+  totalUsado: number
+  totalExpirado: number
+  totalPuntos: number
+  discountRanges: {
+    lt25: number
+    from25to50: number
+    from50to75: number
+    gt75: number
+  }
+  uniqueNeighbors: number
+  newNeighbors: number
+  avgVisitsPerNeighbor: number
+  byCoupon: Array<{
+    couponId: string
+    title: string
+    redemptions: number
+    uniqueNeighbors: number
+    newNeighbors: number
+    pointsSpent: number
+  }>
+}
+
+export default RewardPartnerStats

--- a/src/coupon-transaction/infrastructure/handlers/coupon-transaction.handler.ts
+++ b/src/coupon-transaction/infrastructure/handlers/coupon-transaction.handler.ts
@@ -19,6 +19,7 @@ import type UseCouponPayload from '../../domain/payloads/use-coupon.payload'
 import UseCouponDTO from '../dtos/use-coupon.dto'
 import ListByNeighborUseCase from '../../application/usecases/list-by-neighbor.usecase'
 import ListByRewardPartnerUseCase from '../../application/usecases/list-by-reward-partner.usecase'
+import GetRewardPartnerStatsUseCase from '../../application/usecases/get-reward-partner-stats.usecase'
 import createNotificationDispatcher from '../../../notification/notification-dispatcher.factory'
 
 class CouponTransactionHandler {
@@ -69,12 +70,16 @@ class CouponTransactionHandler {
     }
   }
 
-  async listByNeighbor(req: FastifyRequest<{ Params: Record<string, string> }>, rep: FastifyReply): Promise<void> {
+  async listByNeighbor(
+    req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+    rep: FastifyReply
+  ): Promise<void> {
     try {
       const neighborId = getURLParams(req, 'neighborId')
+      const { offset, limit } = this.optionalPagination(req)
 
       const listByNeighborUseCase = new ListByNeighborUseCase(this.couponTransactionRepository)
-      const transactions = await listByNeighborUseCase.exec(neighborId)
+      const transactions = await listByNeighborUseCase.exec(neighborId, offset, limit)
 
       HandleHTTPResponse.OK(rep, 'Coupon transactions retrieved successfully', transactions)
     } catch (error: any) {
@@ -83,17 +88,60 @@ class CouponTransactionHandler {
     }
   }
 
-  async listByRewardPartner(req: FastifyRequest<{ Params: Record<string, string> }>, rep: FastifyReply): Promise<void> {
+  async listByRewardPartner(
+    req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+    rep: FastifyReply
+  ): Promise<void> {
     try {
       const rewardPartnerId = getURLParams(req, 'rewardPartnerId')
+      const { offset, limit } = this.optionalPagination(req)
 
       const listByRewardPartnerUseCase = new ListByRewardPartnerUseCase(this.couponTransactionRepository)
-      const transactions = await listByRewardPartnerUseCase.exec(rewardPartnerId)
+      const transactions = await listByRewardPartnerUseCase.exec(rewardPartnerId, offset, limit)
 
       HandleHTTPResponse.OK(rep, 'Coupon transactions retrieved successfully', transactions)
     } catch (error: any) {
       const statusCode = error.code || (error.message?.includes('not found') ? 404 : 500)
       rep.status(statusCode).send({ message: error.message })
+    }
+  }
+
+  async getRewardPartnerStats(
+    req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+    rep: FastifyReply
+  ): Promise<void> {
+    try {
+      const rewardPartnerId = getURLParams(req, 'rewardPartnerId')
+      const { from, to } = req.query
+
+      const getStatsUseCase = new GetRewardPartnerStatsUseCase(this.couponTransactionRepository)
+      const stats = await getStatsUseCase.exec(
+        rewardPartnerId,
+        from != null ? new Date(from) : undefined,
+        to != null ? new Date(to) : undefined
+      )
+
+      HandleHTTPResponse.OK(rep, 'Reward partner stats retrieved successfully', stats)
+    } catch (error: any) {
+      const statusCode = error.code || (error.message?.includes('not found') ? 404 : 500)
+      rep.status(statusCode).send({ message: error.message })
+    }
+  }
+
+  // offset/limit son genuinamente opcionales acá (a diferencia de
+  // getPaginationParams, que exige ambos): sin ellos, el endpoint sigue
+  // devolviendo la lista completa como siempre.
+  private optionalPagination(req: FastifyRequest<{ Querystring: Record<string, string> }>): {
+    offset?: number
+    limit?: number
+  } {
+    const rawOffset = req.query.offset
+    const rawLimit = req.query.limit
+    const offset = rawOffset != null && rawOffset !== '' ? parseInt(rawOffset) : undefined
+    const limit = rawLimit != null && rawLimit !== '' ? parseInt(rawLimit) : undefined
+    return {
+      offset: offset != null && !Number.isNaN(offset) ? offset : undefined,
+      limit: limit != null && !Number.isNaN(limit) ? limit : undefined
     }
   }
 

--- a/src/coupon-transaction/infrastructure/repositories/mikro-orm/coupon-transaction.mikroorm.repository.ts
+++ b/src/coupon-transaction/infrastructure/repositories/mikro-orm/coupon-transaction.mikroorm.repository.ts
@@ -1,8 +1,10 @@
 import { RequestContext } from '@mikro-orm/core'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import ErrorEntityManagerNotFound from '../../../../shared/domain/errors/entity-manager-not-found.error'
 import type Nullable from '../../../../shared/domain/types/nullable.type'
 import CouponTransactionEntity from '../../../domain/entities/coupon-transaction.entity'
 import type CouponTransactionRepository from '../../../domain/repositories/coupon-transaction.repository'
+import type RewardPartnerStats from '../../../domain/types/reward-partner-stats.type'
 
 class CouponTransactionMikroORMRepository implements CouponTransactionRepository {
   list!: (offset?: number | undefined, limit?: number | undefined) => Promise<Nullable<CouponTransactionEntity[]>>
@@ -15,21 +17,35 @@ class CouponTransactionMikroORMRepository implements CouponTransactionRepository
   // Lecturas de historial: desactivamos el filtro 'active' para que los maestros
   // referenciados (coupon, rewardPartner, neighbor) se populen aunque estén dados
   // de baja. Si no, el populate los traería null y rompería el render del histórico.
-  async findByNeighbor(neighborId: string): Promise<CouponTransactionEntity[]> {
+  async findByNeighbor(neighborId: string, offset?: number, limit?: number): Promise<CouponTransactionEntity[]> {
     const em = this.getEntityManager()
     return await em.find(
       CouponTransactionEntity,
       { neighbor: neighborId },
-      { populate: ['coupon', 'rewardPartner'], filters: { active: false } }
+      {
+        populate: ['coupon', 'rewardPartner'],
+        filters: { active: false },
+        ...(offset != null ? { offset } : {}),
+        ...(limit != null ? { limit } : {})
+      }
     )
   }
 
-  async findByRewardPartner(rewardPartnerId: string): Promise<CouponTransactionEntity[]> {
+  async findByRewardPartner(
+    rewardPartnerId: string,
+    offset?: number,
+    limit?: number
+  ): Promise<CouponTransactionEntity[]> {
     const em = this.getEntityManager()
     return await em.find(
       CouponTransactionEntity,
       { rewardPartner: rewardPartnerId },
-      { populate: ['coupon', 'neighbor'], filters: { active: false } }
+      {
+        populate: ['coupon', 'neighbor'],
+        filters: { active: false },
+        ...(offset != null ? { offset } : {}),
+        ...(limit != null ? { limit } : {})
+      }
     )
   }
 
@@ -70,6 +86,120 @@ class CouponTransactionMikroORMRepository implements CouponTransactionRepository
     return entity
   }
 
+  async getRewardPartnerStats(rewardPartnerId: string, from?: Date, to?: Date): Promise<RewardPartnerStats> {
+    const knex = this.getKnex()
+
+    // Primera visita de cada vecino a ESTE local, sin filtro de fecha: sirve
+    // para distinguir "vecino nuevo" (su primera visita cayó en el período
+    // filtrado) de un vecino recurrente, sin importar qué rango se esté
+    // mirando en la pantalla.
+    const firstVisitRows = await knex('coupon_transactions')
+      .where('reward_partner_id', rewardPartnerId)
+      .andWhere('status', 'USADO')
+      .groupBy('neighbor_id')
+      .select('neighbor_id as neighborId', knex.raw('MIN(redeem_date) as "firstVisit"'))
+
+    const firstVisitByNeighbor = new Map<string, number>()
+    for (const row of firstVisitRows as Array<{ neighborId: string; firstVisit: string }>) {
+      firstVisitByNeighbor.set(row.neighborId, new Date(row.firstVisit).getTime())
+    }
+
+    const rowsQuery = knex('coupon_transactions as ct')
+      .join('coupon as c', 'ct.coupon_id', 'c.id')
+      .where('ct.reward_partner_id', rewardPartnerId)
+      .select(
+        'ct.status as status',
+        'ct.coupon_id as couponId',
+        'c.title as couponTitle',
+        'c.discount as couponDiscount',
+        'ct.neighbor_id as neighborId',
+        'ct.redeem_date as redeemDate',
+        'ct.cost_in_points as costInPoints'
+      )
+
+    // Mismo criterio de fecha que usaba el filtro client-side: la fecha "de
+    // referencia" de una transacción es redeem_date si existe, si no
+    // adquisition_date, si no created_at.
+    const dateRef = knex.raw('COALESCE(ct.redeem_date, ct.adquisition_date, ct.created_at)')
+    if (from != null) rowsQuery.andWhere(dateRef, '>=', from)
+    if (to != null) rowsQuery.andWhere(dateRef, '<=', to)
+
+    const rows = (await rowsQuery) as Array<{
+      status: string
+      couponId: string
+      couponTitle: string
+      couponDiscount: number
+      neighborId: string
+      redeemDate: string | null
+      costInPoints: number
+    }>
+
+    const totalAdquirido = rows.filter(r => r.status === 'ADQUIRIDO').length
+    const totalUsado = rows.filter(r => r.status === 'USADO').length
+    const totalExpirado = rows.filter(r => r.status === 'EXPIRADO').length
+    const totalPuntos = rows.filter(r => r.status === 'USADO').reduce((sum, r) => sum + (r.costInPoints ?? 0), 0)
+
+    const discountRanges = { lt25: 0, from25to50: 0, from50to75: 0, gt75: 0 }
+    for (const r of rows) {
+      const d = r.couponDiscount ?? 0
+      if (d < 25) discountRanges.lt25++
+      else if (d < 50) discountRanges.from25to50++
+      else if (d < 75) discountRanges.from50to75++
+      else discountRanges.gt75++
+    }
+
+    const usados = rows.filter(r => r.status === 'USADO' && r.redeemDate != null)
+    const isFirstVisit = (r: (typeof usados)[number]): boolean =>
+      r.redeemDate != null && firstVisitByNeighbor.get(r.neighborId) === new Date(r.redeemDate).getTime()
+
+    const uniqueNeighbors = new Set(usados.map(r => r.neighborId)).size
+    const newNeighbors = usados.filter(isFirstVisit).length
+    const avgVisitsPerNeighbor = uniqueNeighbors > 0 ? usados.length / uniqueNeighbors : 0
+
+    const byCouponMap = new Map<
+      string,
+      {
+        couponId: string
+        title: string
+        redemptions: number
+        neighbors: Set<string>
+        newNeighbors: number
+        pointsSpent: number
+      }
+    >()
+    for (const r of usados) {
+      const entry = byCouponMap.get(r.couponId) ?? {
+        couponId: r.couponId,
+        title: r.couponTitle,
+        redemptions: 0,
+        neighbors: new Set<string>(),
+        newNeighbors: 0,
+        pointsSpent: 0
+      }
+      entry.redemptions++
+      entry.neighbors.add(r.neighborId)
+      entry.pointsSpent += r.costInPoints ?? 0
+      if (isFirstVisit(r)) entry.newNeighbors++
+      byCouponMap.set(r.couponId, entry)
+    }
+
+    const byCoupon = Array.from(byCouponMap.values())
+      .map(({ neighbors, ...rest }) => ({ ...rest, uniqueNeighbors: neighbors.size }))
+      .sort((a, b) => b.newNeighbors - a.newNeighbors)
+
+    return {
+      totalAdquirido,
+      totalUsado,
+      totalExpirado,
+      totalPuntos,
+      discountRanges,
+      uniqueNeighbors,
+      newNeighbors,
+      avgVisitsPerNeighbor,
+      byCoupon
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   private getEntityManager() {
     const em = RequestContext.getEntityManager()
@@ -78,6 +208,15 @@ class CouponTransactionMikroORMRepository implements CouponTransactionRepository
     }
 
     return em
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  private getKnex() {
+    const em = RequestContext.getEntityManager() as EntityManager
+    if (em == null) {
+      throw new ErrorEntityManagerNotFound()
+    }
+    return em.getKnex()
   }
 }
 

--- a/src/coupon-transaction/infrastructure/routes/coupon-transaction.route.ts
+++ b/src/coupon-transaction/infrastructure/routes/coupon-transaction.route.ts
@@ -25,14 +25,29 @@ class CouponTransactionRoute {
     })
     this.server.get('/api/coupon-transaction/neighbor/:neighborId', {
       preHandler: this.server.protect(Roles.NEIGHBOR, Roles.ENTITY, Roles.RESPONSIBLE),
-      handler: async (req: FastifyRequest<{ Params: Record<string, string> }>, rep) => {
+      handler: async (
+        req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+        rep
+      ) => {
         await this.handler.listByNeighbor(req, rep)
       }
     })
     this.server.get('/api/coupon-transaction/reward-partner/:rewardPartnerId', {
       preHandler: this.server.protect(Roles.REWARD_PARTNER, Roles.ENTITY, Roles.RESPONSIBLE),
-      handler: async (req: FastifyRequest<{ Params: Record<string, string> }>, rep) => {
+      handler: async (
+        req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+        rep
+      ) => {
         await this.handler.listByRewardPartner(req, rep)
+      }
+    })
+    this.server.get('/api/coupon-transaction/reward-partner/:rewardPartnerId/stats', {
+      preHandler: this.server.protect(Roles.REWARD_PARTNER, Roles.ENTITY, Roles.RESPONSIBLE),
+      handler: async (
+        req: FastifyRequest<{ Params: Record<string, string>; Querystring: Record<string, string> }>,
+        rep
+      ) => {
+        await this.handler.getRewardPartnerStats(req, rep)
       }
     })
     this.server.get('/api/coupon-transaction/:id', {

--- a/src/coupon-transaction/test/coupon-transaction.test.ts
+++ b/src/coupon-transaction/test/coupon-transaction.test.ts
@@ -142,6 +142,107 @@ describe('CouponTransaction — integration tests', () => {
       expect(res.statusCode).toBe(200)
       expect(res.json().data.length).toBe(0)
     })
+
+    it('respeta offset/limit cuando se pasan, sin romper el caso sin params', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/redeem-coupon',
+        headers: { authorization: `Bearer ${neighborToken}` },
+        body: { couponId, neighborId }
+      })
+
+      const sinParams = await app.inject({
+        method: 'GET',
+        url: `/api/coupon-transaction/neighbor/${neighborId}`,
+        headers: { authorization: `Bearer ${neighborToken}` }
+      })
+      expect(sinParams.json().data.length).toBe(1)
+
+      const conLimite = await app.inject({
+        method: 'GET',
+        url: `/api/coupon-transaction/neighbor/${neighborId}?offset=0&limit=1`,
+        headers: { authorization: `Bearer ${neighborToken}` }
+      })
+      expect(conLimite.statusCode).toBe(200)
+      expect(conLimite.json().data.length).toBe(1)
+    })
+  })
+
+  describe('GET /api/coupon-transaction/reward-partner/:rewardPartnerId/stats', () => {
+    it('devuelve stats en cero para un local sin canjes', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/coupon-transaction/reward-partner/${rewardPartnerId}/stats`,
+        headers: { authorization: `Bearer ${rewardPartnerToken}` }
+      })
+      expect(res.statusCode).toBe(200)
+      const data = res.json().data
+      expect(data.totalUsado).toBe(0)
+      expect(data.uniqueNeighbors).toBe(0)
+      expect(data.newNeighbors).toBe(0)
+      expect(data.byCoupon).toEqual([])
+    })
+
+    it('cuenta un canje usado como vecino nuevo, con los puntos gastados', async () => {
+      const redeemRes = await app.inject({
+        method: 'POST',
+        url: '/api/redeem-coupon',
+        headers: { authorization: `Bearer ${neighborToken}` },
+        body: { couponId, neighborId }
+      })
+      const code = redeemRes.json().data.code
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/coupon-transaction/use',
+        headers: { authorization: `Bearer ${rewardPartnerToken}` },
+        body: { code, rewardPartnerId, totalAmount: 1000 }
+      })
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/coupon-transaction/reward-partner/${rewardPartnerId}/stats`,
+        headers: { authorization: `Bearer ${rewardPartnerToken}` }
+      })
+      expect(res.statusCode).toBe(200)
+      const data = res.json().data
+      expect(data.totalUsado).toBe(1)
+      expect(data.totalPuntos).toBe(50)
+      expect(data.uniqueNeighbors).toBe(1)
+      expect(data.newNeighbors).toBe(1)
+      expect(data.avgVisitsPerNeighbor).toBe(1)
+      expect(data.byCoupon.length).toBe(1)
+      expect(data.byCoupon[0].couponId).toBe(couponId)
+      expect(data.byCoupon[0].redemptions).toBe(1)
+      expect(data.byCoupon[0].newNeighbors).toBe(1)
+      expect(data.byCoupon[0].pointsSpent).toBe(50)
+    })
+
+    it('filtra por rango de fechas con from/to', async () => {
+      const redeemRes = await app.inject({
+        method: 'POST',
+        url: '/api/redeem-coupon',
+        headers: { authorization: `Bearer ${neighborToken}` },
+        body: { couponId, neighborId }
+      })
+      const code = redeemRes.json().data.code
+      await app.inject({
+        method: 'POST',
+        url: '/api/coupon-transaction/use',
+        headers: { authorization: `Bearer ${rewardPartnerToken}` },
+        body: { code, rewardPartnerId, totalAmount: 1000 }
+      })
+
+      const mañana = new Date()
+      mañana.setDate(mañana.getDate() + 1)
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/coupon-transaction/reward-partner/${rewardPartnerId}/stats?from=${mañana.toISOString()}`,
+        headers: { authorization: `Bearer ${rewardPartnerToken}` }
+      })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().data.totalUsado).toBe(0)
+    })
   })
 
   describe('GET /api/coupon-transaction/:id', () => {


### PR DESCRIPTION
Nuevo GET /api/coupon-transaction/reward-partner/:id/stats: calcula en SQL (2 queries + compose en JS, mismo patrón que el módulo statistics) lo que hoy hace estadisticas-local.component.ts trayendo todo el historial y agregando en el browser — conteos por estado, puntos, rangos de descuento, vecinos únicos/nuevos y desglose por cupón.

findByNeighbor/findByRewardPartner suman offset/limit opcionales (retrocompatibles: sin params, comportamiento idéntico a hoy) para uso futuro. No se paginan por completo todavía porque catalogo-cupones y home-local dependen del historial completo para funcionar bien (dedup de cupones ya canjeados, filtro/orden client-side).