### PR TITLE
fix(cors): tolerar esquema o slash final en CORS_ALLOWED_ORIGINS

### DIFF
--- a/src/shared/config/fastify-cors.config.ts
+++ b/src/shared/config/fastify-cors.config.ts
@@ -1,7 +1,18 @@
 import { type OriginFunction } from '@fastify/cors'
 import EnvVar from './env-var.config'
 
-const allowedOrigins: string[] = EnvVar.cors.allowedOrigins
+// Tolerates CORS_ALLOWED_ORIGINS entries configured with a scheme/trailing slash
+// (e.g. "https://greenbin.up.railway.app/") by reducing everything to the bare hostname.
+function toHostname(value: string): string {
+  const trimmed = value.trim()
+  try {
+    return new URL(trimmed).hostname
+  } catch {
+    return trimmed
+  }
+}
+
+const allowedOrigins: string[] = EnvVar.cors.allowedOrigins.map(toHostname)
 
 // Requests with no Origin header (curl, server-to-server, same-origin) are only trusted outside production.
 const origin: OriginFunction = (origin, cb) => {


### PR DESCRIPTION
Se normaliza cada entrada de CORS_ALLOWED_ORIGINS a su hostname puro antes de compararla contra el Origin de la request. Si la variable de entorno queda cargada como "https://dominio.app/" en vez de solo "dominio.app", el matching anterior fallaba siempre y bloqueaba el request por CORS (afectaba /api/auth/register/request-otp).