### PR TITLE
fix(auth): manejar error de envio de OTP y status codes no numericos

### DIFF
--- a/src/auth/infrastructure/handlers/register-verification.handler.ts
+++ b/src/auth/infrastructure/handlers/register-verification.handler.ts
@@ -36,7 +36,12 @@ class RegisterVerificationHandler {
     const otp = this.otpService.generate()
     const registerToken = this.otpService.createToken(email, otp, userType)
 
-    await this.emailService.sendRegistrationOtp(email, otp)
+    try {
+      await this.emailService.sendRegistrationOtp(email, otp)
+    } catch {
+      HandleHTTPResponse.InternalServerError(rep, 'No se pudo enviar el código de verificación por correo')
+      return
+    }
 
     HandleHTTPResponse.OK(rep, 'Código enviado al correo', { registerToken })
   }

--- a/src/shared/infrastructure/middlewares/error.middleware.ts
+++ b/src/shared/infrastructure/middlewares/error.middleware.ts
@@ -12,8 +12,8 @@ const errorMiddleware: (error: FastifyError, request: FastifyRequest, reply: Fas
     return
   }
 
-  const domainCode = (error as unknown as { code?: number }).code
-  const statusCode = error.statusCode ?? domainCode ?? 400
+  const domainCode = (error as unknown as { code?: unknown }).code
+  const statusCode = error.statusCode ?? (typeof domainCode === 'number' ? domainCode : undefined) ?? 400
   const patchedError = Object.assign(error, { statusCode })
 
   const { message, code, stack } = ErrorFactory.create(patchedError)


### PR DESCRIPTION
sendRegistrationOtp podia rechazar (fallo SMTP/nodemailer) sin try/catch, y el error se propagaba al middleware global. Ahi, error.code de nodemailer es un string (ej. 'EAUTH'), pero se usaba directo como status code numerico via res.status(code), lo que rompia la respuesta y devolvia un 500 generico sin cuerpo util.

- register-verification.handler: captura el fallo de envio de mail y responde 500 con un mensaje claro en vez de dejar que explote.
- error.middleware: solo usa error.code como statusCode si es realmente un number.