### PR TITLE
fix(auth): guard OTP email failures from crashing the error middleware

### DIFF
--- a/src/auth/infrastructure/handlers/password-reset.handler.ts
+++ b/src/auth/infrastructure/handlers/password-reset.handler.ts
@@ -36,7 +36,13 @@ class PasswordResetHandler {
     const otp = this.otpService.generate()
     const token = this.otpService.createToken(email, otp, userType)
 
-    await this.emailService.sendPasswordResetOtp(email, otp)
+    try {
+      await this.emailService.sendPasswordResetOtp(email, otp)
+    } catch (error) {
+      console.error('[PasswordReset] Failed to send OTP email:', error)
+      HandleHTTPResponse.InternalServerError(rep, 'No se pudo enviar el correo de verificación')
+      return
+    }
 
     HandleHTTPResponse.OK(rep, 'Código enviado al correo', { resetToken: token })
   }

--- a/src/auth/infrastructure/handlers/register-verification.handler.ts
+++ b/src/auth/infrastructure/handlers/register-verification.handler.ts
@@ -36,7 +36,13 @@ class RegisterVerificationHandler {
     const otp = this.otpService.generate()
     const registerToken = this.otpService.createToken(email, otp, userType)
 
-    await this.emailService.sendRegistrationOtp(email, otp)
+    try {
+      await this.emailService.sendRegistrationOtp(email, otp)
+    } catch (error) {
+      console.error('[RegisterVerification] Failed to send OTP email:', error)
+      HandleHTTPResponse.InternalServerError(rep, 'No se pudo enviar el correo de verificación')
+      return
+    }
 
     HandleHTTPResponse.OK(rep, 'Código enviado al correo', { registerToken })
   }

--- a/src/shared/infrastructure/middlewares/error.middleware.ts
+++ b/src/shared/infrastructure/middlewares/error.middleware.ts
@@ -12,8 +12,10 @@ const errorMiddleware: (error: FastifyError, request: FastifyRequest, reply: Fas
     return
   }
 
-  const domainCode = (error as unknown as { code?: number }).code
-  const statusCode = error.statusCode ?? domainCode ?? 400
+  const domainCode = (error as unknown as { code?: unknown }).code
+  const isHttpStatusCode =
+    typeof domainCode === 'number' && Number.isInteger(domainCode) && domainCode >= 100 && domainCode <= 599
+  const statusCode = error.statusCode ?? (isHttpStatusCode ? domainCode : 400)
   const patchedError = Object.assign(error, { statusCode })
 
   const { message, code, stack } = ErrorFactory.create(patchedError)


### PR DESCRIPTION
nodemailer errors carry a string .code (e.g. ESOCKET), but the error middleware assumed .code was always a numeric HTTP status and passed it straight to res.status(), crashing the reply on any infra-level email failure. Validate the code before trusting it, and wrap the OTP email sends so failures return a controlled 500 instead.